### PR TITLE
Fix issues with numpy 1.12

### DIFF
--- a/dioptas/controller/CalibrationController.py
+++ b/dioptas/controller/CalibrationController.py
@@ -268,6 +268,13 @@ class CalibrationController(object):
         # convert pixel coord into pixel index
         x, y = int(x), int(y)
 
+        # filter events outside the image
+        shape = self.model.img_model.img_data.shape
+        if not (0 <= x < shape[0]):
+            return
+        if not (0 <= y < shape[1]):
+            return
+
         peak_ind = self.widget.peak_num_sb.value()
         if self.widget.automatic_peak_search_rb.isChecked():
             points = self.model.calibration_model.find_peaks_automatic(x, y, peak_ind - 1)

--- a/dioptas/controller/CalibrationController.py
+++ b/dioptas/controller/CalibrationController.py
@@ -264,6 +264,10 @@ class CalibrationController(object):
             y-Position for the search
         """
         x, y = y, x  # indeces for the img array are transposed compared to the mouse position
+
+        # convert pixel coord into pixel index
+        x, y = int(x), int(y)
+
         peak_ind = self.widget.peak_num_sb.value()
         if self.widget.automatic_peak_search_rb.isChecked():
             points = self.model.calibration_model.find_peaks_automatic(x, y, peak_ind - 1)

--- a/dioptas/controller/MaskController.py
+++ b/dioptas/controller/MaskController.py
@@ -161,6 +161,7 @@ class MaskController(object):
         self.widget.img_widget.auto_range()
 
     def process_click(self, x, y):
+        x, y = int(x), int(y)
         if self.state == 'circle':
             self.draw_circle(x, y)
         elif self.state == 'rectangle':

--- a/dioptas/controller/MaskController.py
+++ b/dioptas/controller/MaskController.py
@@ -198,6 +198,9 @@ class MaskController(object):
 
     def draw_point(self, x, y):
         radius = self.widget.point_size_sb.value()
+        if radius <= 0:
+            # filter point with no radius
+            return
         self.model.mask_model.mask_ellipse(x, y, radius, radius)
         self.plot_mask()
 

--- a/dioptas/model/CalibrationModel.py
+++ b/dioptas/model/CalibrationModel.py
@@ -76,9 +76,9 @@ class CalibrationModel(object):
     def find_peaks_automatic(self, x, y, peak_ind):
         """
         Searches peaks by using the Massif algorithm
-        :param x:
+        :param int x:
             x-coordinate in pixel - should be from original image (not supersampled x-coordinate)
-        :param y:
+        :param int y:
             y-coordinate in pixel - should be from original image (not supersampled y-coordinate)
         :param peak_ind:
             peak/ring index to which the found points will be added
@@ -95,9 +95,9 @@ class CalibrationModel(object):
     def find_peak(self, x, y, search_size, peak_ind):
         """
         Searches a peak around the x,y position. It just searches for the maximum value in a specific search size.
-        :param x:
+        :param int x:
             x-coordinate in pixel - should be from original image (not supersampled x-coordinate)
-        :param y:
+        :param int y:
             y-coordinate in pixel - should be form original image (not supersampled y-coordinate)
         :param search_size:
             the length of the search rectangle in pixels in all direction in which the algorithm searches for

--- a/dioptas/model/MaskModel.py
+++ b/dioptas/model/MaskModel.py
@@ -165,7 +165,7 @@ class MaskModel(object):
         cy = bounding_rect.center().y()
         x_radius = bounding_rect.width() * 0.5
         y_radius = bounding_rect.height() * 0.5
-        self.mask_ellipse(cx, cy, x_radius, y_radius)
+        self.mask_ellipse(int(cx), int(cy), int(x_radius), int(y_radius))
 
     def mask_rect(self, x, y, width, height):
         """
@@ -191,6 +191,7 @@ class MaskModel(object):
         if y_ind1 < 0:
             y_ind1 = 0
 
+        x_ind1, x_ind2, y_ind1, y_ind2 = int(x_ind1), int(x_ind2), int(y_ind1), int(y_ind2)
         self._mask_data[x_ind1:x_ind2, y_ind1:y_ind2] = self.mode
 
     def mask_polygon(self, x, y):


### PR DESCRIPTION
Hi,

Here is some fixes mostly relative to the use of numpy 1.12. In numpy 1.12 it is no more allows to use a float as an index in a numpy array.

This PR fixes issues relative to :
- Peak picking: the 3 first commits fix that + clap mouse input on the image (negative input was accessing to the ending of the image and big values was raising an exception)
- Mask: the 2 last commits fix the mask tool (avoid an exception when the point radius is null, and fix geometry values to int to avoid exceptions)

I check that everywhere you click on a pixel, the conversion from float to int returns the right index.

Here is the most important module versions
```
pip list
fabio (0.5.0a0)
future (0.16.0)
numpy (1.12.0)
pip (8.1.2)
pyFAI (0.14.0a0)
pyqtgraph (0.10.0)
scikit-image (0.10.1)
scikit-learn (0.14.1)
scipy (0.18.1)
silx (0.4.0a0)
six (1.10.0)
```

I dont have anymore problems now.
Let me know what you think.