### PR TITLE
Prevent removal of sole configuration

### DIFF
--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -83,6 +83,8 @@ class DioptasModel(QtCore.QObject):
         """
         Removes the currently selected configuration.
         """
+        if len(self.configurations) == 1:
+            return
         ind = self.configuration_ind
         self.disconnect_models()
         del self.configurations[ind]


### PR DESCRIPTION
An error appears when trying to remove the only existing configuration.