### PR TITLE
Remove cross when saving cake image

### DIFF
--- a/dioptas/controller/integration/ImageController.py
+++ b/dioptas/controller/integration/ImageController.py
@@ -864,6 +864,7 @@ class ImageController(object):
             if filename.endswith('.png'):
                 if self.widget.img_mode == 'Cake':
                     self.widget.img_widget.deactivate_vertical_line()
+                    self.widget.img_widget.deactivate_mouse_click_item()
                 elif self.widget.img_mode == 'Image':
                     self.widget.img_widget.deactivate_circle_scatter()
                     self.widget.img_widget.deactivate_roi()
@@ -873,6 +874,7 @@ class ImageController(object):
 
                 if self.widget.img_mode == 'Cake':
                     self.widget.img_widget.activate_vertical_line()
+                    self.widget.img_widget.activate_mouse_click_item()
                 elif self.widget.img_mode == 'Image':
                     self.widget.img_widget.activate_circle_scatter()
                     if self.roi_active:

--- a/dioptas/widgets/plot_widgets/ImgWidget.py
+++ b/dioptas/widgets/plot_widgets/ImgWidget.py
@@ -375,11 +375,20 @@ class IntegrationImgWidget(MaskImgWidget, CalibrationCakeWidget):
         self.mouse_click_item.setSymbol('+')
         self.mouse_click_item.setSize(15)
         self.mouse_click_item.addPoints([1024], [1024])
-        self.img_view_box.addItem(self.mouse_click_item)
         self.mouse_left_clicked.connect(self.set_mouse_click_position)
+        self.activate_mouse_click_item()
 
     def set_mouse_click_position(self, x, y):
         self.mouse_click_item.setData([x], [y])
+
+    def activate_mouse_click_item(self):
+        if not self.mouse_click_item in self.img_view_box.addedItems:
+            self.img_view_box.addItem(self.mouse_click_item)
+            self.mouse_click_item.setVisible(True) #oddly this is needed for the line to be displayed correctly
+
+    def deactivate_mouse_click_item(self):
+        if self.mouse_click_item in self.img_view_box.addedItems:
+            self.img_view_box.removeItem(self.mouse_click_item)
 
     def set_circle_line(self, tth, cur_tth):
         """


### PR DESCRIPTION
Upon saving a cake png image the cross was appearing in the image (and not where it was clicked actually).
Added functions to deactivate and activate the cross, similar to those for the line.
Perhaps it is possible to combine the cross and the line.