### PR TITLE
Optimize EuXFEL file reading

### DIFF
--- a/dioptas/model/ImgModel.py
+++ b/dioptas/model/ImgModel.py
@@ -250,7 +250,7 @@ class ImgModel(QtCore.QObject):
         except IOError:
             return None
 
-        return {"img_data": karabo_file.get_image(3),
+        return {"img_data": karabo_file.get_image(0),
                 "series_max": karabo_file.series_max,
                 "series_get_image": karabo_file.get_image}
 

--- a/dioptas/model/util/KaraboLoader.py
+++ b/dioptas/model/util/KaraboLoader.py
@@ -38,5 +38,6 @@ class KaraboFile:
         self.current_source = self.sources[source_ind]
 
     def get_image(self, ind):
-        tid, data = self.f.train_from_index(ind)
+        sel = self.f.select(self.current_source, 'data.image.pixels')
+        tid, data = sel.train_from_index(ind)
         return data[self.current_source]['data.image.pixels']


### PR DESCRIPTION
This should significantly speed up loading data as by default it is loading all datasets.

this selects the relevant data source and property and only load this in memory.