### PR TITLE
Fixed a problem with exporting the table in jcpds editor.

### DIFF
--- a/dioptas/controller/integration/phase/JcpdsEditorController.py
+++ b/dioptas/controller/integration/phase/JcpdsEditorController.py
@@ -328,13 +328,13 @@ class JcpdsEditorController(QtCore.QObject):
 
     def export_table_data(self, filename):
         fp = open(filename, 'w', encoding='utf-8')
-        for col in range(self.jcpds_widget.reflection_table_view.columnCount()):
-            fp.write(self.jcpds_widget.reflection_table_view.horizontalHeaderItem(col).text() + '\t')
+        for col in range(self.jcpds_widget.reflection_table_model.columnCount()):
+            fp.write(self.jcpds_widget.reflection_table_model.header_labels[col] + '\t')
         fp.write('\n')
-        for row in range(self.jcpds_widget.reflection_table_view.rowCount()):
+        for row in range(self.jcpds_widget.reflection_table_model.rowCount()):
             line = ''
-            for col in range(self.jcpds_widget.reflection_table_view.columnCount()):
-                line = line + self.jcpds_widget.reflection_table_view.item(row, col).text() + '\t'
+            for col in range(self.jcpds_widget.reflection_table_model.columnCount()):
+                line = line + self.jcpds_widget.reflection_table_model.index(row, col).data() + '\t'
             line = line + '\n'
             fp.write(line)
         fp.close()

--- a/dioptas/tests/controller_tests/test_JcpdsEditorController.py
+++ b/dioptas/tests/controller_tests/test_JcpdsEditorController.py
@@ -72,6 +72,7 @@ class JcpdsEditorControllerTest(QtTest):
         self.model.delete_configurations()
         del self.model
         delete_if_exists(os.path.join(jcpds_path, 'dummy.jcpds'))
+        delete_if_exists(os.path.join(data_path, 'reflection_table.txt'))
         gc.collect()
 
     # Utility Functions
@@ -270,3 +271,9 @@ class JcpdsEditorControllerTest(QtTest):
                                     'HAHA this is a phase you will never see in your pattern')
         self.assertEqual(self.controller.jcpds_phase.params['comments'][0],
                          'HAHA this is a phase you will never see in your pattern')
+
+    def test_export_reflection_table(self):
+        path = os.path.join(data_path, 'reflection_table.txt')
+        self.controller.export_table_data(path)
+        with open(path, 'r') as f:
+            self.assertEqual(len(f.readlines()), 21)


### PR DESCRIPTION
Looks like the JCPDS table was changed to a view+model which caused a problem.
A test needs to be written to make sure this works and doesn't break again.