### PR TITLE
Correction of control flow in v/v0 calculation at zero pressure. 

### DIFF
--- a/dioptas/model/util/jcpds.py
+++ b/dioptas/model/util/jcpds.py
@@ -519,7 +519,7 @@ class jcpds(object):
 
         if pressure == 0.:
             self.params['v'] = self.params['v0'] * (1 + self.params['alpha_t'] * (temperature - 298.))
-        if pressure < 0:
+        elif pressure < 0:
             if self.params['k0'] <= 0.:
                 logger.info('K0 is zero, computing zero pressure volume')
                 self.params['v'] = self.params['v0']


### PR DESCRIPTION
Unit cell volumes were being incorrectly calculated when P==0 due to the result being over written by the P>0 calculation. As a result, the parameter K' was affecting the unit cell volume at zero pressure.

 "if" to "elif" to avoid overwriting the P=0 v/v0 calculation in jcpds.py