### PR TITLE
Fix image import indexing in Batch Integration

### DIFF
--- a/dioptas/model/BatchModel.py
+++ b/dioptas/model/BatchModel.py
@@ -248,7 +248,7 @@ class BatchModel(QtCore.QObject):
                 current_file = file_index
                 self.calibration_model.img_model.load(self.files[file_index])
 
-            self.calibration_model.img_model.load_series_img(pos)
+            self.calibration_model.img_model.load_series_img(pos+1)
             binning, intensity = self.calibration_model.integrate_1d(num_points=num_points,
                                                                      mask=mask)
             image_counter += 1


### PR DESCRIPTION
The 0th and 1st 1d.integrated patterns generated through Batch integration are duplicates.
The indexing for all other patterns are offset and the final 2D image is not integrated.
Fixes the indexing error to pass the correct 2D image to BatchModel.integrate_raw_data()
Error is a result of 0 based indexing in Batch Integration that is modified through ImgModel.load_series_img()