### PR TITLE
Add a Reset colormap range button to the colorbar

### DIFF
--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -60,6 +60,7 @@ class HistogramLUTItem(GraphicsWidget):
     sigLookupTableChanged = QtCore.Signal(object)
     sigLevelsChanged = QtCore.Signal(object)
     sigLevelChangeFinished = QtCore.Signal(object)
+    sigResetClicked = QtCore.Signal()
 
     def __init__(self, image=None, fillHistogram=False, orientation='horizontal', autoLevel=None):
         """
@@ -84,6 +85,19 @@ class HistogramLUTItem(GraphicsWidget):
         self.gradient = GradientEditorItem()
         self.gradient.loadPreset('grey')
 
+        resetButton = QtWidgets.QToolButton()
+        resetButton.setIcon(
+            QtWidgets.QApplication.instance().style().standardIcon(
+                QtWidgets.QStyle.SP_BrowserReload
+            )
+        )
+        resetButton.setIconSize(QtCore.QSize(15, 15))
+        resetButton.setToolTip("Rescale colormap range")
+        resetButton.clicked.connect(self.sigResetClicked)
+
+        proxy = QtWidgets.QGraphicsProxyWidget()
+        proxy.setWidget(resetButton)
+
         if orientation == 'horizontal':
             self.vb.setMouseEnabled(x=True, y=False)
             self.vb.setMaximumHeight(30)
@@ -92,6 +106,7 @@ class HistogramLUTItem(GraphicsWidget):
             self.region = LogarithmRegionItem([0, 1], LinearRegionItem.Vertical)
             self.layout.addItem(self.vb, 1, 0)
             self.layout.addItem(self.gradient, 0, 0)
+            self.layout.addItem(proxy, 1, 1)
             self.gradient.setFlag(self.gradient.ItemStacksBehindParent)
             self.vb.setFlag(self.gradient.ItemStacksBehindParent)
         elif orientation == 'vertical':
@@ -102,6 +117,7 @@ class HistogramLUTItem(GraphicsWidget):
             self.region = LogarithmRegionItem([0, 1], LinearRegionItem.Horizontal)
             self.layout.addItem(self.vb, 0, 0)
             self.layout.addItem(self.gradient, 0, 1)
+            self.layout.addItem(proxy, 1, 0)
 
         self.gradient.setFlag(self.gradient.ItemStacksBehindParent)
         self.vb.setFlag(self.gradient.ItemStacksBehindParent)

--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+import pathlib
 from qtpy import QtWidgets, QtCore
 from pyqtgraph.graphicsItems.GraphicsWidget import GraphicsWidget
 from pyqtgraph.graphicsItems.ViewBox import *
@@ -31,6 +32,9 @@ from pyqtgraph.Point import Point
 import pyqtgraph.functions as fn
 import pyqtgraph as pg
 import numpy as np
+from ..CustomWidgets import FlatButton
+from ... import style_path
+
 
 __all__ = ['HistogramLUTItem']
 
@@ -85,7 +89,10 @@ class HistogramLUTItem(GraphicsWidget):
         self.gradient = GradientEditorItem()
         self.gradient.loadPreset('grey')
 
-        resetButton = QtWidgets.QToolButton()
+        resetButton = FlatButton()
+        resetButton.setStyleSheet(
+            pathlib.Path(style_path, "stylesheet.qss").read_text()
+        )
         resetButton.setIcon(
             QtWidgets.QApplication.instance().style().standardIcon(
                 QtWidgets.QStyle.SP_BrowserReload

--- a/dioptas/widgets/plot_widgets/ImgWidget.py
+++ b/dioptas/widgets/plot_widgets/ImgWidget.py
@@ -58,8 +58,10 @@ class ImgWidget(QtCore.QObject):
         self.img_view_box.addItem(self.data_img_item)
 
         self.img_histogram_LUT_horizontal = HistogramLUTItem(self.data_img_item)
+        self.img_histogram_LUT_horizontal.sigResetClicked.connect(self.auto_level)
         self.pg_layout.addItem(self.img_histogram_LUT_horizontal, row=0, col=1)
         self.img_histogram_LUT_vertical = HistogramLUTItem(self.data_img_item, orientation='vertical')
+        self.img_histogram_LUT_vertical.sigResetClicked.connect(self.auto_level)
         self.pg_layout.addItem(self.img_histogram_LUT_vertical, row=1, col=2)
 
     def create_mouse_click_item(self):

--- a/dioptas/widgets/plot_widgets/SurfaceWidget.py
+++ b/dioptas/widgets/plot_widgets/SurfaceWidget.py
@@ -69,10 +69,17 @@ class SurfaceWidget(QtWidgets.QWidget):
         self.img_histogram_LUT_horizontal.sigLevelsChanged.connect(self.update_color)
         self.img_histogram_LUT_horizontal.sigLevelChangeFinished.connect(self.update_color)
         self.img_histogram_LUT_horizontal.sigLookupTableChanged.connect(self.update_color)
+        self.img_histogram_LUT_horizontal.sigResetClicked.connect(self._reset_clicked)
 
         self.lut_pg_layout.addItem(self.img_histogram_LUT_horizontal, 0, 1)
 
         self.setLayout(self._layout)
+
+    def _reset_clicked(self):
+        if self.data is not None:
+            self.img_histogram_LUT_horizontal.setLevels(
+                np.nanmin(self.data), np.nanmax(self.data)
+            )
 
     def create_graphics(self):
         self.back_grid = GLGridItem()


### PR DESCRIPTION
This is a proposition to close #143.

It adds a button in `HistogramLUTItem` to enable the user to reset the colormap range to what is done by `auto_levels` when loading the image in the first place.


<img width="400px" src="https://github.com/Dioptas/Dioptas/assets/9449698/529825a5-f982-42ed-adc7-db124ed02be8" />
