### PR TITLE
Update pyproject.toml build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,4 @@ pytest-qt = "*"
 
 [build-system]
 requires = ["poetry-core", "cython", "setuptools", "poetry-dynamic-versioning"]
-build-backend = ["poetry.core.masonry.api", "poetry_dynamic_versioning.backend"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
Running `pip install .` fails without this patch:

```
% pip install .            
Processing src/Dioptas
  Installing build dependencies ... done
  ERROR: Error expected str, bytes or os.PathLike object, not list while executing command Getting requirements to build wheel
  Getting requirements to build wheel ... error
ERROR: Exception:
Traceback (most recent call last):
  File "lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 169, in exc_logging_wrapper
    status = run_func(*args)
[...]
  File "lib/python3.10/os.py", line 810, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not list
```

According to [PEP517](https://peps.python.org/pep-0517/#source-trees), `build-backend` is a string, and [poetry-dynamic-versioning's doc](https://github.com/mtkennerly/poetry-dynamic-versioning#installation) uses:
```
build-backend = "poetry_dynamic_versioning.backend"
```