### PR TITLE
Add image colormap normalization

### DIFF
--- a/dioptas/tests/widget_tests/test_ColormapPopup.py
+++ b/dioptas/tests/widget_tests/test_ColormapPopup.py
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Test ColormapDialog widget"""
+"""Test ColormapPopup widget"""
 
 import pytest
 from qtpy import QtCore, QtWidgets

--- a/dioptas/tests/widget_tests/test_ColormapPopup.py
+++ b/dioptas/tests/widget_tests/test_ColormapPopup.py
@@ -28,21 +28,9 @@ import pyqtgraph.graphicsItems.GradientEditorItem
 from ...widgets.plot_widgets.ColormapPopup import ColormapPopup
 
 
-@pytest.fixture
-def colormapPopup(qapp):
-    """Fixture providing an instance of a ColormapPopup"""
-    widget = ColormapPopup()
-    widget.show()
-    QTest.qWaitForWindowExposed(widget)
-    try:
-        yield widget
-    finally:
-        widget.close()
-        qapp.processEvents()
-
-
-def testRange(colormapPopup):
+def testRange(qWidgetFactory):
     """"Test getRange, setRange and sigRangeChanged"""
+    colormapPopup = qWidgetFactory(ColormapPopup)
     assert colormapPopup.getRange() == (1, 1)
 
     signalSpy = QSignalSpy(colormapPopup.sigRangeChanged)
@@ -58,8 +46,9 @@ def testRange(colormapPopup):
     assert colormapPopup.getRange() == (1000, 2000)
 
 
-def testCurrentGradient(colormapPopup):
+def testCurrentGradient(qWidgetFactory):
     """Test getCurrentGradient, setCurrentGradient and sigCurrentGradientChanged"""
+    colormapPopup = qWidgetFactory(ColormapPopup)
     for firstName, firstGradient in pyqtgraph.graphicsItems.GradientEditorItem.Gradients.items():
         break
     gradient = colormapPopup.getCurrentGradient()
@@ -76,8 +65,9 @@ def testCurrentGradient(colormapPopup):
     assert signalSpy[0] == [viridisGradient]
 
 
-def testCustomGradient(colormapPopup):
+def testCustomGradient(qWidgetFactory):
     """Test setCurrentGradient with a custom gradient"""
+    colormapPopup = qWidgetFactory(ColormapPopup)
     signalSpy = QSignalSpy(colormapPopup.sigCurrentGradientChanged)
 
     customGradient = {

--- a/dioptas/tests/widget_tests/test_ColormapPopup.py
+++ b/dioptas/tests/widget_tests/test_ColormapPopup.py
@@ -93,7 +93,7 @@ def testCustomGradient(qWidgetFactory):
     assert signalSpy[1] == [customGradient2]
 
 
-@pytest.mark.parametrize("normalization", ["log", "sqrt", "arcsinh"])
+@pytest.mark.parametrize("normalization", ["log", "sqrt"])
 def testCurrentNormalization(qWidgetFactory, normalization):
     """Test getCurrentNormalization, setCurrentNormalization and sigCurrentNormalizationChanged"""
     colormapPopup = qWidgetFactory(ColormapPopup)

--- a/dioptas/tests/widget_tests/test_ColormapPopup.py
+++ b/dioptas/tests/widget_tests/test_ColormapPopup.py
@@ -29,7 +29,7 @@ from ...widgets.plot_widgets.ColormapPopup import ColormapPopup
 
 
 def testRange(qWidgetFactory):
-    """"Test getRange, setRange and sigRangeChanged"""
+    """Test getRange, setRange and sigRangeChanged"""
     colormapPopup = qWidgetFactory(ColormapPopup)
     assert colormapPopup.getRange() == (1, 1)
 
@@ -91,3 +91,22 @@ def testCustomGradient(qWidgetFactory):
     assert colormapPopup._gradientComboBox.currentText() == 'Custom'
     assert len(signalSpy) == 2
     assert signalSpy[1] == [customGradient2]
+
+
+@pytest.mark.parametrize("normalization", ["log", "sqrt", "arcsinh"])
+def testCurrentNormalization(qWidgetFactory, normalization):
+    """Test getCurrentNormalization, setCurrentNormalization and sigCurrentNormalizationChanged"""
+    colormapPopup = qWidgetFactory(ColormapPopup)
+
+    default_normalization = colormapPopup.getCurrentNormalization()
+    assert default_normalization == "linear"
+    assert colormapPopup._normalizationComboBox.currentText() == "Linear"
+    assert colormapPopup._normalizationComboBox.currentData() == "linear"
+
+    signalSpy = QSignalSpy(colormapPopup.sigCurrentNormalizationChanged)
+    colormapPopup.setCurrentNormalization(normalization)
+    returned_normalization = colormapPopup.getCurrentNormalization()
+    assert returned_normalization == normalization
+    assert colormapPopup._normalizationComboBox.currentData() == normalization
+    assert len(signalSpy) == 1
+    assert signalSpy[0] == [normalization]

--- a/dioptas/tests/widget_tests/test_NormalizedImageItem.py
+++ b/dioptas/tests/widget_tests/test_NormalizedImageItem.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Dioptas - GUI program for fast processing of 2D X-ray diffraction data
+# Principal author: Clemens Prescher (clemens.prescher@gmail.com)
+# Copyright (C) 2014-2019 GSECARS, University of Chicago, USA
+# Copyright (C) 2015-2018 Institute for Geology and Mineralogy, University of Cologne, Germany
+# Copyright (C) 2019-2020 DESY, Hamburg, Germany
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Test NormalizedImageItem pyqtgraph's GraphicObject"""
+
+import numpy as np
+
+import pytest
+from pyqtgraph import GraphicsLayoutWidget
+from qtpy import QtCore
+from qtpy.QtTest import QSignalSpy, QTest
+
+from dioptas.widgets.plot_widgets.NormalizedImageItem import NormalizedImageItem
+
+NORMALIZATIONS = tuple(NormalizedImageItem._NORMALIZATIONS.keys())
+
+
+@pytest.fixture
+def normalizedImageItem(qapp, qWidgetFactory):
+    """Fixture providing a NormalizedImageItem displayed in a GraphicsLayoutWidget"""
+    widget = qWidgetFactory(GraphicsLayoutWidget)
+    viewbox = widget.addViewBox(row=1, col=1)
+
+    item = NormalizedImageItem()
+    viewbox.addItem(item)
+
+    yield item
+    qapp.processEvents()
+
+
+def testDefaultItem(normalizedImageItem):
+    """Test NormalizedImageItem default values"""
+    normalization = normalizedImageItem.getNormalization()
+    assert normalization == "linear"
+    data = normalizedImageItem.getData(copy=False)
+    assert data is None
+    levels = normalizedImageItem.getLevels()
+    assert levels is None
+
+
+@pytest.mark.parametrize("normalization", NORMALIZATIONS)
+def testSetLevels(normalizedImageItem, normalization):
+    """Test setLevels with different normalizations"""
+    normalizedImageItem.setNormalization(normalization)
+    assert normalizedImageItem.getNormalization() == normalization
+    assert normalizedImageItem.getLevels() is None
+
+    normalizedImageItem.setLevels((1, 10))
+    levels = normalizedImageItem.getLevels()
+    assert np.allclose(levels, (1, 10))
+
+
+@pytest.mark.parametrize("normalization", NORMALIZATIONS)
+def testSetImage(qapp, normalizedImageItem, normalization):
+    """Test setImage with different normalizations"""
+    normalizedImageItem.setNormalization(normalization)
+
+    ref_image = np.arange(10000, dtype=np.float32).reshape(100, 100)
+    min_max = ref_image.min(), ref_image.max()
+
+    normalizedImageItem.setImage(ref_image)
+    qapp.processEvents()
+
+    data = normalizedImageItem.getData(copy=False)
+    assert np.array_equal(ref_image, data)
+
+    levels = normalizedImageItem.getLevels()
+    assert np.allclose(levels, min_max)
+
+    assert normalizedImageItem.quickMinMax() == min_max

--- a/dioptas/widgets/plot_widgets/ColormapPopup.py
+++ b/dioptas/widgets/plot_widgets/ColormapPopup.py
@@ -34,6 +34,9 @@ class ColormapPopup(QtWidgets.QFrame):
     sigCurrentGradientChanged = QtCore.Signal(dict)
     """Signal emitted when the colormap gradient has changed"""
 
+    sigCurrentNormalizationChanged = QtCore.Signal(str)
+    """Signal emitted when the colormap normalization has changed"""
+
     sigRangeChanged = QtCore.Signal(float, float)
     """Signal emitted when the data range has changed"""
 
@@ -62,6 +65,16 @@ class ColormapPopup(QtWidgets.QFrame):
             self._gradientComboBox.addItem(icon, name.capitalize(), gradient)
         self._gradientComboBox.currentIndexChanged.connect(self._gradientComboBoxCurrentIndexChanged)
         layout.addRow('Colormap:', self._gradientComboBox)
+
+        self._normalizationComboBox = QtWidgets.QComboBox(self)
+        self._normalizationComboBox.addItem("Linear", "linear")
+        self._normalizationComboBox.addItem("Logarithmic", "log")
+        self._normalizationComboBox.addItem("Square root", "sqrt")
+        self._normalizationComboBox.addItem("Arcsinh", "arcsinh")
+
+        self._normalizationComboBox.setCurrentIndex(0)
+        self._normalizationComboBox.currentIndexChanged.connect(self._normalizationComboBoxCurrentIndexChanged)
+        layout.addRow('Normalization:', self._normalizationComboBox)
 
         layout.addRow(QtWidgets.QLabel('Range:'))
         self._minEdit = QtWidgets.QLineEdit(self)
@@ -102,6 +115,12 @@ class ColormapPopup(QtWidgets.QFrame):
         gradient = self._gradientComboBox.itemData(index, QtCore.Qt.UserRole)
         self.sigCurrentGradientChanged.emit(gradient)
 
+    def _normalizationComboBoxCurrentIndexChanged(self, index: int):
+        if index < 0:
+            return
+        normalization = self._normalizationComboBox.itemData(index, QtCore.Qt.UserRole)
+        self.sigCurrentNormalizationChanged.emit(normalization)
+
     def setCurrentGradient(self, gradient: dict):
         """Set the currently selected gradient
 
@@ -122,6 +141,17 @@ class ColormapPopup(QtWidgets.QFrame):
     def getCurrentGradient(self) -> dict:
         """Returns the currently selected gradient"""
         return self._gradientComboBox.currentData()
+
+    def setCurrentNormalization(self, normalization: str):
+        """Set the currently selected normalization"""
+        index = self._normalizationComboBox.findData(normalization)
+        if index < 0:
+            raise ValueError(f"Unsupported normalization: {normalization}")
+        self._normalizationComboBox.setCurrentIndex(index)
+
+    def getCurrentNormalization(self) -> str:
+        """Returns the currently selected normalization"""
+        return self._normalizationComboBox.currentData()
 
     def _rangeChanged(self):
         minimum, maximum = self.getRange()

--- a/dioptas/widgets/plot_widgets/ColormapPopup.py
+++ b/dioptas/widgets/plot_widgets/ColormapPopup.py
@@ -25,6 +25,7 @@ from qtpy import QtGui, QtCore, QtWidgets
 import pyqtgraph.graphicsItems.GradientEditorItem
 
 from . import utils
+from .NormalizedImageItem import NormalizedImageItem
 from ... import style_path
 
 
@@ -67,9 +68,9 @@ class ColormapPopup(QtWidgets.QFrame):
         layout.addRow('Colormap:', self._gradientComboBox)
 
         self._normalizationComboBox = QtWidgets.QComboBox(self)
-        self._normalizationComboBox.addItem("Linear", "linear")
-        self._normalizationComboBox.addItem("Logarithmic", "log")
-        self._normalizationComboBox.addItem("Square root", "sqrt")
+        for normalization in NormalizedImageItem.supportedNormalizations():
+            description = NormalizedImageItem.getNormalizationDescription(normalization).capitalize()
+            self._normalizationComboBox.addItem(description, normalization)
 
         self._normalizationComboBox.setCurrentIndex(0)
         self._normalizationComboBox.currentIndexChanged.connect(self._normalizationComboBoxCurrentIndexChanged)

--- a/dioptas/widgets/plot_widgets/ColormapPopup.py
+++ b/dioptas/widgets/plot_widgets/ColormapPopup.py
@@ -70,7 +70,6 @@ class ColormapPopup(QtWidgets.QFrame):
         self._normalizationComboBox.addItem("Linear", "linear")
         self._normalizationComboBox.addItem("Logarithmic", "log")
         self._normalizationComboBox.addItem("Square root", "sqrt")
-        self._normalizationComboBox.addItem("Arcsinh", "arcsinh")
 
         self._normalizationComboBox.setCurrentIndex(0)
         self._normalizationComboBox.currentIndexChanged.connect(self._normalizationComboBoxCurrentIndexChanged)

--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -90,6 +90,8 @@ class HistogramLUTItem(GraphicsWidget):
         self.gradient = GradientEditorItem()
         self.gradient.loadPreset('grey')
 
+        self._normalizationLabel = pg.LabelItem("linear")
+
         configurationButton = FlatButton()
         configurationButton.setWidth(30)
         configurationButton.setHeight(30)
@@ -112,6 +114,7 @@ class HistogramLUTItem(GraphicsWidget):
             self.region = LogarithmRegionItem([0, 1], LinearRegionItem.Vertical)
             self.layout.addItem(self.vb, 1, 0)
             self.layout.addItem(self.gradient, 0, 0)
+            self.layout.addItem(self._normalizationLabel, 1, 1)
             self.layout.addItem(proxy, 0, 1)
             self.gradient.setFlag(self.gradient.ItemStacksBehindParent)
             self.vb.setFlag(self.gradient.ItemStacksBehindParent)
@@ -123,6 +126,7 @@ class HistogramLUTItem(GraphicsWidget):
             self.region = LogarithmRegionItem([0, 1], LinearRegionItem.Horizontal)
             self.layout.addItem(self.vb, 0, 0)
             self.layout.addItem(self.gradient, 0, 1)
+            self.layout.addItem(self._normalizationLabel, 1, 0)
             self.layout.addItem(proxy, 1, 1)
 
         self.gradient.setFlag(self.gradient.ItemStacksBehindParent)
@@ -223,6 +227,8 @@ class HistogramLUTItem(GraphicsWidget):
 
     def setImageItem(self, img):
         self.imageItem = img
+        self._updateNormalizationLabel(
+            img.getNormalization() if isinstance(img, NormalizedImageItem) else "linear")
         img.sigImageChanged.connect(self.imageChanged)
         img.setLookupTable(self.getLookupTable)  ## send function pointer, not the result
         # self.gradientChanged()
@@ -329,7 +335,14 @@ class HistogramLUTItem(GraphicsWidget):
         self.gradient.restoreState(gradient)
         self.gradientChanged()
 
+    def _updateNormalizationLabel(self, normalization: str):
+        shortname = NormalizedImageItem.getNormalizationShortname(normalization)
+        description = NormalizedImageItem.getNormalizationDescription(normalization).capitalize()
+        self._normalizationLabel.setText(shortname)
+        self._normalizationLabel.setToolTip(f"{description} colormap normalization")
+
     def _normalizationChanged(self, normalization: str):
+        self._updateNormalizationLabel(normalization)
         if isinstance(self.imageItem, NormalizedImageItem):
             self.imageItem.setNormalization(normalization)
             sender = self.sender()

--- a/dioptas/widgets/plot_widgets/ImgWidget.py
+++ b/dioptas/widgets/plot_widgets/ImgWidget.py
@@ -29,6 +29,7 @@ from skimage.measure import find_contours
 from qtpy import QtCore, QtWidgets, QtGui
 
 from .HistogramLUTItem import HistogramLUTItem
+from .NormalizedImageItem import NormalizedImageItem
 from .PatternWidget import ModifiedLinearRegionItem
 from . import utils
 
@@ -55,7 +56,7 @@ class ImgWidget(QtCore.QObject):
     def create_graphics(self):
         self.img_view_box = self.pg_layout.addViewBox(row=1, col=1)  # type: ViewBox
 
-        self.data_img_item = pg.ImageItem()
+        self.data_img_item = NormalizedImageItem()
         self.img_view_box.addItem(self.data_img_item)
 
         self.img_histogram_LUT_horizontal = HistogramLUTItem(self.data_img_item)

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# Dioptas - GUI program for fast processing of 2D X-ray diffraction data
+# Principal author: Clemens Prescher (clemens.prescher@gmail.com)
+# Copyright (C) 2014-2019 GSECARS, University of Chicago, USA
+# Copyright (C) 2015-2018 Institute for Geology and Mineralogy, University of Cologne, Germany
+# Copyright (C) 2019-2020 DESY, Hamburg, Germany
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+from typing import Optional
+
+import numpy as np
+import pyqtgraph as pg
+
+
+class Normalization:
+    """Class defining the interface for implementing normalizations"""
+
+    @staticmethod
+    def apply(data: np.ndarray) -> np.ndarray:
+        """Forward conversion of data to normalized data"""
+        raise NotImplementedError()
+
+    @staticmethod
+    def revert(data: np.ndarray) -> np.ndarray:
+        """Backward conversion of normalized data to data"""
+        raise NotImplementedError()
+
+    @staticmethod
+    def invalid(data: np.ndarray) -> np.ndarray:
+        """Returns True for data that cannot be normalized"""
+        return np.zeros(data.shape, dtype=bool)
+
+
+class LinearNormalization(Normalization):
+    @staticmethod
+    def apply(data: np.ndarray) -> np.ndarray:
+        return data
+
+    @staticmethod
+    def revert(data: np.ndarray) -> np.ndarray:
+        return data
+
+
+class LogNormalization(Normalization):
+    @staticmethod
+    def apply(data: np.ndarray) -> np.ndarray:
+        return np.log10(data)
+
+    @staticmethod
+    def revert(data: np.ndarray) -> np.ndarray:
+        return np.power(10, data)
+
+    @staticmethod
+    def invalid(data: np.ndarray) -> np.ndarray:
+        return data <= 0.0
+
+
+class SqrtNormalization(Normalization):
+    @staticmethod
+    def apply(data: np.ndarray) -> np.ndarray:
+        return np.sqrt(data)
+
+    @staticmethod
+    def revert(data: np.ndarray) -> np.ndarray:
+        return data * data
+
+    @staticmethod
+    def invalid(data: np.ndarray) -> np.ndarray:
+        return data < 0.0
+
+
+class ArcsinhNormalization(Normalization):
+    @staticmethod
+    def apply(data: np.ndarray) -> np.ndarray:
+        return np.arcsinh(data)
+
+    @staticmethod
+    def revert(data: np.ndarray) -> np.ndarray:
+        return np.sinh(data)
+
+
+class NormalizedImageItem(pg.ImageItem):
+    """pyqtgraph image item with support for data normalization"""
+
+    _NORMALIZATIONS = {
+        "linear": LinearNormalization(),
+        "log": LogNormalization(),
+        "sqrt": SqrtNormalization(),
+        "arcsinh": ArcsinhNormalization(),
+    }
+    """Dict of normalization name: Normalization instances"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__normalization = "linear"
+        self.__rawImage = None
+
+    def getData(self, copy: bool = True) -> Optional[np.ndarray]:
+        """Returns the image data array
+
+        :param copy: False to return the array used internally: do not modify!
+        """
+        if self.__rawImage is None:
+            return None
+        return np.array(self.__rawImage, copy=copy)
+
+    def getNormalization(self) -> str:
+        """Returns the currently used normalization"""
+        return self.__normalization
+
+    def setNormalization(self, normalization: str):
+        """Set the data normalization to use"""
+        if normalization not in self._NORMALIZATIONS:
+            raise ValueError(f"Unsupported normalization: {normalization}")
+
+        if normalization == self.__normalization:
+            return
+
+        # Get levels **before** changing the normalization
+        levels = self.getLevels()
+        self.__normalization = normalization
+        self.setImage(image=self.__rawImage, levels=levels)
+
+    def _getNorm(self) -> Normalization:
+        return self._NORMALIZATIONS[self.getNormalization()]
+
+    def setImage(self, image=None, *args, **kwargs):
+        if image is None:
+            return super().setImage(None, *args, **kwargs)
+
+        self.__rawImage = image
+        normalizedImage = self._getNorm().apply(image)
+        return super().setImage(normalizedImage, *args, **kwargs)
+
+    def getLevels(self):
+        levels = super().getLevels()
+        return self._getNorm().revert(levels)
+
+    def setLevels(self, levels, update=True):
+        normalizedLevels = self._getNorm().apply(levels)
+        return super().setLevels(normalizedLevels, update)
+
+    @contextmanager
+    def _useAsImage(self, image: Optional[np.ndarray]):
+        """Context to temporarily use provided image as image attribute
+
+        Used when calling ImageItem methods that needs to access a different
+        image than the transformed one.
+        """
+        previousImage = self.image
+        self.image = image
+        try:
+            yield
+        finally:
+            self.image = previousImage
+
+    def quickMinMax(self, *args, **kwargs):
+        with self._useAsImage(self.__rawImage):
+            return super().quickMinMax(*args, **kwargs)
+
+    def getHistogram(self, *args, **kwargs):
+        if self.__rawImage is None:
+            return super().getHistogram(*args, **kwargs)
+
+        # Filter invalid values for current normalization
+        invalid = self._getNorm().invalid(self.__rawImage)
+        if not np.any(invalid):
+            filteredImage = self.__rawImage
+
+        else:  # Replace invalid values with NaNs
+            dtype = self.__rawImage.dtype
+            if not np.issubdtype(dtype, np.floating):
+                dtype = np.float64
+            filteredImage = np.array(self.__rawImage, copy=True, dtype=dtype)
+
+            filteredImage[invalid] = np.nan
+
+        with self._useAsImage(filteredImage):
+            return super().getHistogram(*args, **kwargs)

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -174,21 +174,5 @@ class NormalizedImageItem(pg.ImageItem):
             return super().quickMinMax(*args, **kwargs)
 
     def getHistogram(self, *args, **kwargs):
-        if self.__rawImage is None:
-            return super().getHistogram(*args, **kwargs)
-
-        # Filter invalid values for current normalization
-        invalid = self._getNorm().invalid(self.__rawImage)
-        if not np.any(invalid):
-            filteredImage = self.__rawImage
-
-        else:  # Replace invalid values with NaNs
-            dtype = self.__rawImage.dtype
-            if not np.issubdtype(dtype, np.floating):
-                dtype = np.float64
-            filteredImage = np.array(self.__rawImage, copy=True, dtype=dtype)
-
-            filteredImage[invalid] = np.nan
-
-        with self._useAsImage(filteredImage):
+        with self._useAsImage(self.__rawImage):
             return super().getHistogram(*args, **kwargs)

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -84,16 +84,6 @@ class SqrtNormalization(Normalization):
         return data < 0.0
 
 
-class ArcsinhNormalization(Normalization):
-    @staticmethod
-    def apply(data: np.ndarray) -> np.ndarray:
-        return np.arcsinh(data)
-
-    @staticmethod
-    def revert(data: np.ndarray) -> np.ndarray:
-        return np.sinh(data)
-
-
 class NormalizedImageItem(pg.ImageItem):
     """pyqtgraph image item with support for data normalization"""
 
@@ -101,7 +91,6 @@ class NormalizedImageItem(pg.ImageItem):
         "linear": LinearNormalization(),
         "log": LogNormalization(),
         "sqrt": SqrtNormalization(),
-        "arcsinh": ArcsinhNormalization(),
     }
     """Dict of normalization name: Normalization instances"""
 

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -149,9 +149,14 @@ class NormalizedImageItem(pg.ImageItem):
 
     def getLevels(self):
         levels = super().getLevels()
+        if levels is None:
+            return None
         return self._getNorm().revert(levels)
 
     def setLevels(self, levels, update=True):
+        if levels is None:
+            return super().setLevels(levels, update)
+
         normalizedLevels = self._getNorm().apply(levels)
         return super().setLevels(normalizedLevels, update)
 


### PR DESCRIPTION
This PR adds different colormap normalizations, namely: 'linear', 'log', 'sqrt' and 'arcsinh', that can be selected from the colormap popup widget.

To support this, I added an item that inherits from `pyqtgraph`'s `ImageItem` and apply a normalization to the displayed data.

There is no test yet: If you are OK with the approach, I'll add tests for this.

Related to #150