### PR TITLE
Normalization followup

### DIFF
--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -90,7 +90,7 @@ class HistogramLUTItem(GraphicsWidget):
         self.gradient = GradientEditorItem()
         self.gradient.loadPreset('grey')
 
-        self._normalizationLabel = pg.LabelItem("linear")
+        self._normalizationLabel = pg.LabelItem("")
 
         configurationButton = FlatButton()
         configurationButton.setWidth(30)

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -60,7 +60,7 @@ class Normalization:
 
 class LinearNormalization(Normalization):
     ID = "linear"
-    SHORTNAME = "lin"
+    SHORTNAME = "⟋"
     DESCRIPTION = "linear"
 
     @staticmethod
@@ -74,7 +74,7 @@ class LinearNormalization(Normalization):
 
 class LogNormalization(Normalization):
     ID = "log"
-    SHORTNAME = ID
+    SHORTNAME = "㏒"
     DESCRIPTION = "logarithmic"
 
     @staticmethod

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -51,7 +51,10 @@ class Normalization:
 
     @staticmethod
     def invalid(data: np.ndarray) -> np.ndarray:
-        """Returns True for data that cannot be normalized"""
+        """Element-wise invalidity test
+
+        Returns a boolean array which is True for data elements that cannot be normalized.
+        """
         return np.zeros(data.shape, dtype=bool)
 
 


### PR DESCRIPTION
This PR addresses review comments from #158:
- Update docstring
- Use / for linear (and unicode log caracter) for normalization short name
- Remove default value of the normalization label
