### PR TITLE
Make sure hist_x and hist_y are defined

### DIFF
--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -79,6 +79,8 @@ class HistogramLUTItem(GraphicsWidget):
         self.percentageLevel = False
         self.orientation = orientation
         self.autoLevel = autoLevel
+        self.hist_x = np.array([0.])
+        self.hist_y = np.array([0.])
 
         self.layout = QtWidgets.QGraphicsGridLayout()
         self.setLayout(self.layout)
@@ -271,6 +273,8 @@ class HistogramLUTItem(GraphicsWidget):
         if img_data is None:
             img_data = self.imageItem.getData(copy=False)
             if img_data is None:
+                self.hist_x = np.array([0.])
+                self.hist_y = np.array([0.])
                 return
 
         log_data = np.log(img_data)

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
+from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Optional


### PR DESCRIPTION
This a fix to avoid an exception when `hist_x` and `hist_y` are not set:
```
<class 'AttributeError'>: 
'HistogramLUTItem' object has no attribute 'hist_y'
--------------------------------------------------------------------------------
  File "/Users/tvincent/src/Dioptas/dioptas/widgets/plot_widgets/HistogramLUTItem.py", line 320, in _configurationButtonClicked
    widget.setDataHistogram(counts=self.hist_y, bins=self.hist_x)
```

To reproduce: start dioptas, select the "Cake" tab on the top bar and press the colormap settings icon.

This PR makes sure those attributes are set in the `__init__` method.
