### PR TITLE
defer start-up QMessageBox display and exec

### DIFF
--- a/dioptas/controller/MainController.py
+++ b/dioptas/controller/MainController.py
@@ -78,7 +78,7 @@ class MainController(object):
         self.update_title()
 
         if use_settings:
-            self.load_default_settings()
+            QtCore.QTimer.singleShot(0, self.load_default_settings)
             self.setup_backup_timer()
 
         self.current_tab_index = 0


### PR DESCRIPTION
This PR fixes an issue on macos with pyqt6>=6.5 where displaying a `QMessageBox` before `app.exec` prevent from displaying extra windows 🤷 ..

This PR proposes to display the QMessageBox after the call of `app.exec` by using a `QTimer`, so the method will be called once the event loop is started.

closes #163