### PR TITLE
Use PyQt6 by default

### DIFF
--- a/dioptas/__init__.py
+++ b/dioptas/__init__.py
@@ -20,8 +20,17 @@
 
 from __future__ import absolute_import
 
+import os
 import sys
 from sys import platform as _platform
+
+# If QT_API is not set, use PyQt6 by default
+if "QT_API" not in os.environ:
+    try:
+        import PyQt6.QtCore
+    except ImportError:
+        pass
+
 from qtpy import QtWidgets
 
 __version__ = "0.5.8-dev-alpha"


### PR DESCRIPTION
`qtpy` loads pyqt5 by default (then in order pyside2, pyqt6, pyside6):

https://github.com/spyder-ide/qtpy/blob/1faf764ef7444f9eb16bcf16dc7376e1f120b67d/qtpy/__init__.py#L172-L173

So if pyqt5 (or pyside2) is installed in an environment, Dioptas will use it instead of pyqt6.

This PR proposes to try to import PyQt6 first to force `qtpy` to use it unless the user has selected a Qt binding with the `QT_API` env var (used by `qtpy`).
