### PR TITLE
Revert colormap range management when switching tabs

### DIFF
--- a/dioptas/controller/MainController.py
+++ b/dioptas/controller/MainController.py
@@ -138,11 +138,11 @@ class MainController(object):
         old_view_range = None
         if old_index == 0:  # calibration tab
             old_view_range = self.widget.calibration_widget.img_widget.img_view_box.targetRange()
-            old_hist_levels = self.widget.calibration_widget.img_widget.img_histogram_LUT_vertical.getExpLevels()
+            old_hist_levels = self.widget.calibration_widget.img_widget.img_histogram_LUT_horizontal.getExpLevels()
             self.old_hist_levels[0] = old_hist_levels
         elif old_index == 1:  # mask tab
             old_view_range = self.widget.mask_widget.img_widget.img_view_box.targetRange()
-            old_hist_levels = self.widget.mask_widget.img_widget.img_histogram_LUT_vertical.getExpLevels()
+            old_hist_levels = self.widget.mask_widget.img_widget.img_histogram_LUT_horizontal.getExpLevels()
             self.old_hist_levels[1] = old_hist_levels
         elif old_index == 2:
             old_view_range = self.widget.integration_widget.img_widget.img_view_box.targetRange()


### PR DESCRIPTION
Following https://github.com/Dioptas/Dioptas/issues/160#issuecomment-1715245109 and https://github.com/Dioptas/Dioptas/pull/162#issuecomment-1710330717, this PR reverts PR #159.