### PR TITLE
Keep colormap normalization when switching between calibration, mask and integration tabs

### DIFF
--- a/dioptas/controller/MainController.py
+++ b/dioptas/controller/MainController.py
@@ -140,14 +140,17 @@ class MainController(object):
             old_view_range = self.widget.calibration_widget.img_widget.img_view_box.targetRange()
             old_hist_levels = self.widget.calibration_widget.img_widget.img_histogram_LUT_horizontal.getExpLevels()
             self.old_hist_levels[0] = old_hist_levels
+            normalization = self.widget.calibration_widget.img_widget.img_histogram_LUT_vertical.getNormalization()
         elif old_index == 1:  # mask tab
             old_view_range = self.widget.mask_widget.img_widget.img_view_box.targetRange()
             old_hist_levels = self.widget.mask_widget.img_widget.img_histogram_LUT_horizontal.getExpLevels()
             self.old_hist_levels[1] = old_hist_levels
+            normalization = self.widget.mask_widget.img_widget.img_histogram_LUT_vertical.getNormalization()
         elif old_index == 2:
             old_view_range = self.widget.integration_widget.img_widget.img_view_box.targetRange()
             old_hist_levels = self.widget.integration_widget.img_widget.img_histogram_LUT_horizontal.getExpLevels()
             self.old_hist_levels[2] = old_hist_levels
+            normalization = self.widget.integration_widget.img_widget.img_histogram_LUT_horizontal.getNormalization()
 
             # update the GUI
         if ind == 2:  # integration tab
@@ -173,6 +176,7 @@ class MainController(object):
             else:
                 self.widget.integration_widget.img_widget.img_histogram_LUT_horizontal.setLevels(*old_hist_levels)
                 self.widget.integration_widget.img_widget.img_histogram_LUT_vertical.setLevels(*old_hist_levels)
+            self.widget.integration_widget.img_widget.img_histogram_LUT_horizontal.setNormalization(normalization)
         elif ind == 1:  # mask tab
             self.mask_controller.plot_mask()
             self.mask_controller.plot_image()
@@ -181,6 +185,7 @@ class MainController(object):
                 self.widget.mask_widget.img_widget.img_histogram_LUT_vertical.setLevels(*(self.old_hist_levels[1]))
             else:
                 self.widget.mask_widget.img_widget.img_histogram_LUT_vertical.setLevels(*old_hist_levels)
+            self.widget.mask_widget.img_widget.img_histogram_LUT_vertical.setNormalization(normalization)
         elif ind == 0:  # calibration tab
             self.calibration_controller.plot_mask()
             try:
@@ -193,6 +198,7 @@ class MainController(object):
                     *(self.old_hist_levels[0]))
             else:
                 self.widget.calibration_widget.img_widget.img_histogram_LUT_vertical.setLevels(*old_hist_levels)
+            self.widget.calibration_widget.img_widget.img_histogram_LUT_vertical.setNormalization(normalization)
 
     def update_title(self):
         """

--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -229,8 +229,7 @@ class HistogramLUTItem(GraphicsWidget):
 
     def setImageItem(self, img):
         self.imageItem = img
-        self._updateNormalizationLabel(
-            img.getNormalization() if isinstance(img, NormalizedImageItem) else "linear")
+        self._updateNormalizationLabel(self.getNormalization())
         img.sigImageChanged.connect(self.imageChanged)
         img.setLookupTable(self.getLookupTable)  ## send function pointer, not the result
         # self.gradientChanged()
@@ -311,6 +310,21 @@ class HistogramLUTItem(GraphicsWidget):
         if self.imageItem is not None:
             self.imageItem.setLevels(np.exp(self.region.getRegion()))
 
+    def getNormalization(self) -> str:
+        """Returns the current image normalization"""
+        if isinstance(self.imageItem, NormalizedImageItem):
+            return self.imageItem.getNormalization()
+        return "linear"
+
+    def setNormalization(self, normalization: str):
+        """Set image current normalization
+
+        This has effect only if the associated image item is a NormalizedImageItem.
+        """
+        if isinstance(self.imageItem, NormalizedImageItem):
+            self.imageItem.setNormalization(normalization)
+        self._updateNormalizationLabel(normalization)
+
     def empty_function(self, *args):
         pass
 
@@ -318,8 +332,7 @@ class HistogramLUTItem(GraphicsWidget):
         widget = ColormapPopup(parent=self.scene().views()[0])
 
         widget.setCurrentGradient(self.gradient.saveState())
-        if isinstance(self.imageItem, NormalizedImageItem):
-            widget.setCurrentNormalization(self.imageItem.getNormalization())
+        widget.setCurrentNormalization(self.getNormalization())
         widget.setRange(*self.getExpLevels())
         widget.setDataHistogram(counts=self.hist_y, bins=self.hist_x)
         widget.sigCurrentGradientChanged.connect(self._configurationGradientChanged)


### PR DESCRIPTION
This PR proposes to keep the last selected colormap normalization for the 3 tabs: calibration, mask, integration.
This is implemented in a similar way as preserving the zoomed area.

Related to #160