### PR TITLE
Filter gaps before colormap autoscale

### DIFF
--- a/dioptas/tests/unit_tests/test_AutoLevel.py
+++ b/dioptas/tests/unit_tests/test_AutoLevel.py
@@ -92,3 +92,20 @@ def test_unsupported_autoscale_mode():
     data = np.array([1, 2, 3])
     with pytest.raises(ValueError):
         range_ = auto_level.get_range(data)
+
+
+def test_filter_dummy():
+    auto_level = AutoLevel()
+    auto_level.mode = "minmax"
+    auto_level.filter_dummy = True
+    data = np.array([
+        [ 0,  1,  2,  3,  4],
+        [-1, -1, -1, -1, -1],
+        [-1, -1, -1, -1, -1],
+        [ 4,  3,  2,  1,  0],
+    ])
+    range_ = auto_level.get_range(data)
+    assert range_ == (0, 4)
+
+    range_ = auto_level.get_range(np.transpose(data))
+    assert range_ == (0, 4)

--- a/dioptas/widgets/plot_widgets/ColormapPopup.py
+++ b/dioptas/widgets/plot_widgets/ColormapPopup.py
@@ -128,6 +128,12 @@ class ColormapPopup(QtWidgets.QFrame):
 
         self._resetButtonGroup.buttonClicked.connect(self._autoscaleRequested)
 
+        self._filterGapsCheckBox = QtWidgets.QCheckBox(self)
+        self._filterGapsCheckBox.setToolTip("Toggle detector gaps value filtering")
+        self._filterGapsCheckBox.setChecked(utils.auto_level.filter_dummy)
+        self._filterGapsCheckBox.toggled.connect(self._autoscaleRequested)
+        layout.addRow('Filter gaps:', self._filterGapsCheckBox)
+
         buttonBox = QtWidgets.QDialogButtonBox(parent=self)
         buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Close)
         closeButton = buttonBox.button(QtWidgets.QDialogButtonBox.Close)
@@ -225,6 +231,7 @@ class ColormapPopup(QtWidgets.QFrame):
 
     def _autoscaleRequested(self, *args):
         utils.auto_level.mode = self._getResetMode()
+        utils.auto_level.filter_dummy = self._filterGapsCheckBox.isChecked()
         colormapRange = utils.auto_level.get_range(self.getData(copy=False))
         if colormapRange is None:
              return

--- a/dioptas/widgets/plot_widgets/utils.py
+++ b/dioptas/widgets/plot_widgets/utils.py
@@ -86,10 +86,36 @@ def _percentile_auto_level(
     return float(lower), float(upper)
 
 
+def detector_gap_mask(data: np.ndarray) -> np.ndarray:
+    """Probe detector gap value and returns mask of pixels not belonging to gaps.
+
+    :param data: 2D image array for which to compute the mask
+    :returns: Mask with True for valid pixels and False for mask
+    """
+    if data.ndim != 2:
+        raise ValueError("2D array only are supported")
+
+    # Find columns with same values
+    equal_columns_mask = np.all(np.equal(data[0], data), axis=0)
+    if not np.any(equal_columns_mask):
+        return np.ones(data.shape, dtype=bool)
+
+    equal_values, counts = np.unique(data[0, equal_columns_mask], return_counts=True)
+    # At least 2 columns and not the whole image
+    mask = np.logical_and(counts > 1, counts < data.shape[1])
+    equal_values = equal_values[mask]
+    counts = counts[mask]
+    if len(equal_values) == 0:
+        return np.ones(data.shape, dtype=bool)
+
+    value = equal_values[np.argmax(counts)]
+    return data != value
+
+
 class AutoLevel:
     """Handle colormap range autoscale computation.
 
-    This class stores settings: autoscale mode
+    This class stores settings: autoscale mode and whether or not to filter dummy value.
 
     Instances of this class are callable:
     >>> auto_level = AutoLevel()
@@ -107,6 +133,9 @@ class AutoLevel:
         self.mode: str = "default"
         """Autoscale mode in 'default', 'minmax', 'mean3std', '%fpercentile'"""
 
+        self.filter_dummy: bool = False
+        """Whether or not to filter detector dummy values"""
+
     def get_range(self, data: Optional[np.ndarray]) -> Optional[tuple[float, float]]:
         """Returns colormap range from data for current settings
 
@@ -115,6 +144,9 @@ class AutoLevel:
         """
         if data is None:
             return None
+
+        if self.filter_dummy:
+            data = data[detector_gap_mask(data)]
 
         filtered_data = data[np.isfinite(data)]
         if filtered_data.size == 0:


### PR DESCRIPTION
This PR ~builds on PR #166 (and includes) and~ adds probing and filtering of gap values before performing the colormap autoscale.

~The 3 added commits are: https://github.com/Dioptas/Dioptas/commit/8df3ad6cb5d6e739e5a4091ae8e8feac73096a5e https://github.com/Dioptas/Dioptas/commit/127b924653ed8c6564810801520aedda464f5373 https://github.com/Dioptas/Dioptas/commit/0263dda7284be6be3344bc4ee78625c47a3d0151~

I tried to retrieve the selected `Detector` in the calibration tab and use pyFAI `Detector.dynamic_mask` but there's a few issues: retrieving the current `Detector` from the `AutoLevel`; the image data looks to be converted to `float32` for display which prevent `Detector.dynamic_mask` to work correctly; the image is transposed for compatibility with pyqtgraph and there is possible transformations to take care of.
So finally, probing the gap value is much simpler. The limitation is that it does not take care of other dummy pixel values.