### PR TITLE
Fixing error of wrongly displayed diffractograms of rhombohedral spacegroups in hexagonal setting

### DIFF
--- a/dioptas/model/util/cif.py
+++ b/dioptas/model/util/cif.py
@@ -484,7 +484,7 @@ class CifPhase(object):
     def get_symmetry_from_space_group_number(self, number):
         if number is not None:
             if number in [146, 148, 155, 160, 161, 166, 167]:
-                if number == 167 and not self.a == self.c:
+                if self.a != self.c:
                     return "HEXAGONAL"
                 else:
                     return "RHOMBOHEDRAL"


### PR DESCRIPTION
This change is to fix an error for wrongly displayed diffractograms for rhombohedral spacegroups in the hexagonal setting.

This was previously fixed for space group number 167, by adding an if statement checking if unit cell parameters a=c.  

However, the other rhombohedral spacegroups can also be in the hexagonal setting, so by checking if a=c for all rhombohedral groups, the symmetry will be correctly assigned if the spacegroup is in the hexagonal setting.