### PR TITLE
Fixes exception in Colormap dialog

### DIFF
--- a/dioptas/widgets/plot_widgets/ColormapPopup.py
+++ b/dioptas/widgets/plot_widgets/ColormapPopup.py
@@ -132,7 +132,9 @@ class ColormapPopup(QtWidgets.QFrame):
         self._filterGapsCheckBox.setToolTip("Toggle detector gaps value filtering")
         self._filterGapsCheckBox.setChecked(utils.auto_level.filter_dummy)
         self._filterGapsCheckBox.toggled.connect(self._autoscaleRequested)
-        layout.addRow('Filter gaps:', self._filterGapsCheckBox)
+        nrows = resetModesLayout.rowCount()
+        resetModesLayout.addWidget(QtWidgets.QLabel('Filter gaps:'), nrows, 0, QtCore.Qt.AlignRight)
+        resetModesLayout.addWidget(self._filterGapsCheckBox, nrows, 1, QtCore.Qt.AlignLeft)
 
         buttonBox = QtWidgets.QDialogButtonBox(parent=self)
         buttonBox.setStandardButtons(QtWidgets.QDialogButtonBox.Close)


### PR DESCRIPTION
closes #174

This issue was introduced in PR #171 that didn't followed propely update of PR #166.
This PR fixes this issue by making the filter checkbox part of the "reset mode" group:

<img width="299" alt="image" src="https://github.com/Dioptas/Dioptas/assets/9449698/ff79f5a6-77e1-453f-a0fa-e6378cce4dae">
