### PR TITLE
Update xypattern version pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ sharedmem = "^0.3.8"
 watchdog = "^3.0.0"
 pyopengl = "^3.1.7"
 pyopengl-accelerate = "^3.1.7"
-xypattern = "1.0.4"
+xypattern = "^1.0.4"
 numpy = [
   { version = "^1.24.0", python = "<3.10" },
   { version = "^1.26.0", python = ">=3.10" }


### PR DESCRIPTION
This PR relaxes the version of xypattern to use so `1.0.5` can be used which allows to install from source distribution

closes #173