### PR TITLE
Fix colormap normalization label

### DIFF
--- a/dioptas/widgets/plot_widgets/HistogramLUTItem.py
+++ b/dioptas/widgets/plot_widgets/HistogramLUTItem.py
@@ -366,7 +366,7 @@ class HistogramLUTItem(GraphicsWidget):
     def _updateNormalizationLabel(self, normalization: str):
         shortname = NormalizedImageItem.getNormalizationShortname(normalization)
         description = NormalizedImageItem.getNormalizationDescription(normalization).capitalize()
-        self._normalizationLabel.setText(shortname)
+        self._normalizationLabel.setText(f"<small>{shortname}</small>")
         self._normalizationLabel.setToolTip(f"{description} colormap normalization")
 
     def _normalizationChanged(self, normalization: str):

--- a/dioptas/widgets/plot_widgets/NormalizedImageItem.py
+++ b/dioptas/widgets/plot_widgets/NormalizedImageItem.py
@@ -60,7 +60,7 @@ class Normalization:
 
 class LinearNormalization(Normalization):
     ID = "linear"
-    SHORTNAME = "⟋"
+    SHORTNAME = "lin"
     DESCRIPTION = "linear"
 
     @staticmethod
@@ -74,7 +74,7 @@ class LinearNormalization(Normalization):
 
 class LogNormalization(Normalization):
     ID = "log"
-    SHORTNAME = "㏒"
+    SHORTNAME = "log"
     DESCRIPTION = "logarithmic"
 
     @staticmethod


### PR DESCRIPTION
It turns out, not all fonts supports "⟋" and "㏒" Unicode characters (found on Linux) which are used for displaying the colormap normalization in the histogram LUT.

This PR replaces those characters with small text.