### PR TITLE
Fixed running with a different user and fixed SyntaxWarning with Python3.12 

### DIFF
--- a/dioptas/__init__.py
+++ b/dioptas/__init__.py
@@ -42,7 +42,6 @@ from .controller.MainController import MainController
 
 theme_path = os.path.join(style_path, "dark_orange.xml")
 qss_path = os.path.join(style_path, "qt_material.css")
-css_out_path = os.path.join(style_path, "dioptas.css")
 
 def main():
     app = QtWidgets.QApplication([])
@@ -52,7 +51,6 @@ def main():
         theme=theme_path,
         css_file=qss_path,
         extra={"density_scale": -2},
-        save_as=css_out_path
     )
     # sys.excepthook = excepthook
     print("Dioptas {}".format(__version__))

--- a/dioptas/_desktop_shortcuts.py
+++ b/dioptas/_desktop_shortcuts.py
@@ -145,7 +145,7 @@ export SCRIPT={prefix:s}/bin/{script:s}
     text = "$PY $SCRIPT"
     if in_terminal:
         text = """
-osascript -e 'tell application "Terminal" to do script "'${{PY}}\ ${{SCRIPT}}'"'
+osascript -e 'tell application "Terminal" to do script "'${{PY}}\\ ${{SCRIPT}}'"'
 """
 
     with open(os.path.join(dest, 'Contents', 'Info.plist'), 'w') as fout:


### PR DESCRIPTION
This PR fixes 2 issues:

- Do not save apply_stylesheet's output since this is causing issue when running with a different user than the one who installed dioptas due to writing into the installation folder
- Fix a SyntaxWarning error due to '\ ' not a correct escape character sequence

closes #185