### PR TITLE
Fixed python3.8 support

### DIFF
--- a/dioptas/model/MapModel2.py
+++ b/dioptas/model/MapModel2.py
@@ -17,6 +17,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import os.path
 
 import numpy as np


### PR DESCRIPTION
This is needed to make it work with Python3.8 due to the use of `list[str]` typing in this file