### PR TITLE
Lazy fix for the case of comma as decimal separator in P and T saved phase list file.

### DIFF
--- a/dioptas/controller/integration/phase/PhaseController.py
+++ b/dioptas/controller/integration/phase/PhaseController.py
@@ -226,8 +226,8 @@ class PhaseController(object):
                 phase_file.write(file_name + ',' + str(phase_cb.isChecked()) + ',' +
                                  color_btn.styleSheet().split(";")[0].replace('background-color:', '').replace(' ', '') + ',' +
                                  self.phase_widget.phase_tw.item(row, 2).text() + ',' +
-                                 self.phase_widget.pressure_sbs[row].text() + ',' +
-                                 self.phase_widget.temperature_sbs[row].text() + '\n')
+                                 self.phase_widget.pressure_sbs[row].text().replace(',','.') + ',' +
+                                 self.phase_widget.temperature_sbs[row].text().replace(',','.') + '\n')
 
     def clear_phases(self):
         """


### PR DESCRIPTION
Hello, 
this corrects the case where the decimal point of the locale settings is "," character, which led to extra commas in the phase_list txt file, and therefore to the impossibility of loading it. This has no effect if the locale decimal separator is set to ".". 