### PR TITLE
ImgModel settings to evented ImgParams state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 # 0.8.7 (in development)
 
+## Bugfixes
+
+- setting an integer intensity factor (e.g. from a script) silently wrapped uint16 image pixel values around; the factor is now coerced to float
+
 ## Internal
+
+- ImgModel's settings (autoprocess, factor, background scaling/offset, file iteration mode) moved into an evented `ImgParams` dataclass following the no-state-in-models direction; the file iteration mode is now persisted in project files (previously lost on save); img params changes surface on `configuration_params_changed` with an `img.` prefix, and the background image scale/offset spinboxes bind reactively to them
 
 - the model Signal class is now backed by psygnal, gaining batched/paused emission while keeping the existing API
 - introduced an evented parameter dataclass layer (`dioptas.model.state`): Configuration settings now live in a `ConfigurationParams` object that is saved generically into project files; the 1D azimuth range and trim-trailing-zeros settings are now persisted (they were previously lost on save)

--- a/dioptas/controller/binding.py
+++ b/dioptas/controller/binding.py
@@ -81,16 +81,24 @@ class Binder:
         self._register(_Binding(render_fn, widgets), field)
 
     def bind_checkbox(
-        self, checkbox: Any, owner: Callable[[], Any], field: str
+        self,
+        checkbox: Any,
+        owner: Callable[[], Any],
+        field: str,
+        event_field: str | None = None,
     ) -> None:
-        """Two-way binding for a QCheckBox-like widget (toggled/isChecked)."""
+        """Two-way binding for a QCheckBox-like widget (toggled/isChecked).
+
+        *event_field* overrides the field-event name to react to when it
+        differs from the attribute name (e.g. namespaced sub-model fields
+        like "img.factor")."""
         checkbox.toggled.connect(
             lambda checked: setattr(owner(), field, bool(checked))
         )
         self.add_render(
             lambda: checkbox.setChecked(bool(getattr(owner(), field))),
             checkbox,
-            field=field,
+            field=event_field or field,
         )
 
     def bind_spinbox(
@@ -99,6 +107,7 @@ class Binder:
         owner: Callable[[], Any],
         field: str,
         dtype: Callable[[Any], Any] = int,
+        event_field: str | None = None,
     ) -> None:
         """Two-way binding for a QSpinBox-like widget (valueChanged/value)."""
         spinbox.valueChanged.connect(
@@ -107,7 +116,7 @@ class Binder:
         self.add_render(
             lambda: spinbox.setValue(getattr(owner(), field)),
             spinbox,
-            field=field,
+            field=event_field or field,
         )
 
     def mirror_toggles(

--- a/dioptas/controller/integration/BackgroundController.py
+++ b/dioptas/controller/integration/BackgroundController.py
@@ -29,13 +29,15 @@ class BackgroundController:
             widget.integration_control_widget.background_control_widget
         )
         self.model = dioptas_model
-        self.binder = Binder()
+        self.binder = Binder(field_events=self.model.configuration_params_changed)
 
         self.model.configuration_selected.connect(self.update_bkg_image_widgets)
         self.model.configuration_selected.connect(self.update_auto_pattern_bkg_widgets)
 
         self.create_image_background_signals()
         self.create_pattern_background_signals()
+        self.binder.connect_refresh(self.model.configuration_selected)
+        self.binder.refresh()
 
     def create_image_background_signals(self):
         self.connect_click_function(
@@ -51,11 +53,19 @@ class BackgroundController:
         self.widget.bkg_image_offset_step_msb.editingFinished.connect(
             self.update_bkg_image_offset_step
         )
-        self.widget.bkg_image_scale_sb.valueChanged.connect(
-            self.background_img_scale_changed
+        self.binder.bind_spinbox(
+            self.widget.bkg_image_scale_sb,
+            lambda: self.model.img_model,
+            "background_scaling",
+            dtype=float,
+            event_field="img.background_scaling",
         )
-        self.widget.bkg_image_offset_sb.valueChanged.connect(
-            self.background_img_offset_changed
+        self.binder.bind_spinbox(
+            self.widget.bkg_image_offset_sb,
+            lambda: self.model.img_model,
+            "background_offset",
+            dtype=float,
+            event_field="img.background_offset",
         )
 
         self.model.img_changed.connect(self.update_background_image_filename)
@@ -153,12 +163,6 @@ class BackgroundController:
         else:
             self.widget.bkg_image_filename_lbl.setText("None")
             self.widget.bkg_name_lbl.setText("")
-
-    def background_img_scale_changed(self):
-        self.model.img_model.background_scaling = self.widget.bkg_image_scale_sb.value()
-
-    def background_img_offset_changed(self):
-        self.model.img_model.background_offset = self.widget.bkg_image_offset_sb.value()
 
     def bkg_pattern_gb_toggled_callback(self, is_checked):
         self.widget.qa_bkg_pattern_inspect_btn.setVisible(is_checked)
@@ -332,8 +336,6 @@ class BackgroundController:
 
     def update_bkg_image_widgets(self):
         self.update_background_image_filename()
-        self.widget.bkg_image_offset_sb.setValue(self.model.img_model.background_offset)
-        self.widget.bkg_image_scale_sb.setValue(self.model.img_model.background_scaling)
         self.widget.img_show_background_subtracted_btn.setVisible(
             self.model.img_model.has_background()
         )

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -13,7 +13,7 @@ from xypattern import Pattern
 from xypattern.auto_background import SmoothBrucknerBackground
 
 from .util import Signal
-from .state import ConfigurationParams, save_params, load_params, Derived
+from .state import ConfigurationParams, ImgParams, save_params, load_params, Derived
 from .util.ImgCorrection import (
     CbnCorrection,
     ObliqueAngleDetectorAbsorptionCorrection,
@@ -571,6 +571,7 @@ class Configuration:
 
         # save image model
         image_group = f.create_group("image_model")
+        save_params(image_group, self.img_model.params)
         image_group.attrs["auto_process"] = self.img_model.autoprocess
         image_group.attrs["factor"] = self.img_model.factor
         image_group.attrs["has_background"] = self.img_model.has_background()
@@ -1086,6 +1087,12 @@ class Configuration:
         if saved_params is not None:
             self.params.oned_azimuth_range = saved_params.oned_azimuth_range
             self.params.trim_trailing_zeros = saved_params.trim_trailing_zeros
+
+        saved_img_params = load_params(f.get("image_model"), ImgParams)
+        if saved_img_params is not None:
+            self.img_model.params.file_iteration_mode = (
+                saved_img_params.file_iteration_mode
+            )
 
         if self.calibration_model.is_calibrated:
             self.integrate_image_1d()

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -80,7 +80,9 @@ class DioptasModel:
 
         # the store-level settings-change surface: forwards every params
         # field change of the CURRENT configuration as (field, new, old);
-        # stable across configuration switches (rewired in connect_models)
+        # stable across configuration switches (rewired in connect_models).
+        # Sub-model params are namespaced by prefix: e.g. the ImgModel's
+        # factor arrives as "img.factor"; Configuration fields are unprefixed.
         self.configuration_params_changed: Signal = Signal(str, object, object)
 
         # convenience signal for the most-consumed field, emitting
@@ -368,6 +370,9 @@ class DioptasModel:
         self.current_configuration.params.events.disconnect(
             self._on_configuration_params_event, missing_ok=True
         )
+        self.img_model.params.events.disconnect(
+            self._on_img_params_event, missing_ok=True
+        )
 
     def connect_models(self) -> None:
         """Connects signals of the currently selected configuration."""
@@ -378,6 +383,7 @@ class DioptasModel:
         self.current_configuration.params.events.connect(
             self._on_configuration_params_event
         )
+        self.img_model.params.events.connect(self._on_img_params_event)
 
     def _on_configuration_params_event(self, info) -> None:
         """Forwards a psygnal EmissionInfo from the current configuration's
@@ -387,6 +393,10 @@ class DioptasModel:
         self.configuration_params_changed.emit(field, new, old)
         if field == "integration_unit":
             self.integration_unit_changed.emit(new, old)
+
+    def _on_img_params_event(self, info) -> None:
+        new, old = info.args
+        self.configuration_params_changed.emit("img." + info.signal.name, new, old)
 
     @property
     def working_directories(self) -> dict[str, str]:

--- a/dioptas/model/ImgModel.py
+++ b/dioptas/model/ImgModel.py
@@ -15,6 +15,7 @@ import h5py
 import fabio
 
 from .util import Signal
+from .state import ImgParams
 from dioptas.model.loader.spe import SpeFile
 from .util.NewFileWatcher import NewFileInDirectoryWatcher
 from .util.HelperModule import rotate_matrix_p90, rotate_matrix_m90, FileNameIterator
@@ -50,7 +51,10 @@ class ImgModel:
         self.filename: str = ""
         self.img_transformations: list[Callable[[np.ndarray], np.ndarray]] = []
 
-        self.file_iteration_mode: str = "number"
+        # All user-settable parameters live in the evented params dataclass;
+        # the properties below delegate to it and add side effects.
+        self.params: ImgParams = ImgParams()
+
         self.file_name_iterator: FileNameIterator = FileNameIterator()
 
         self.series_pos: int = 1
@@ -64,10 +68,6 @@ class ImgModel:
 
         self.background_filename: str = ""
         self._background_data: np.ndarray | None = None
-        self._background_scaling: float = 1
-        self._background_offset: float = 0
-
-        self._factor: float = 1
 
         self.transfer_correction: TransferFunctionCorrection = TransferFunctionCorrection()
         self.flat_field_correction: FlatFieldCorrection = FlatFieldCorrection()
@@ -113,9 +113,6 @@ class ImgModel:
         self.loader: FabioLoader | Hdf5Image | None = None
 
         self._img_corrections: ImgCorrectionManager = ImgCorrectionManager()
-
-        # setting up autoprocess
-        self._autoprocess: bool = False
         # TODO: watching a directory should be open to any file type - an extension should  be added when a
         # new file is loaded with a previous non-existing file extension
         self._directory_watcher: NewFileInDirectoryWatcher = NewFileInDirectoryWatcher(
@@ -404,23 +401,31 @@ class ImgModel:
 
     @property
     def background_scaling(self) -> float:
-        return self._background_scaling
+        return self.params.background_scaling
 
     @background_scaling.setter
     def background_scaling(self, new_value: float) -> None:
-        self._background_scaling = new_value
+        self.params.background_scaling = float(new_value)
         self._calculate_img_data()
         self.img_changed.emit()
 
     @property
     def background_offset(self) -> float:
-        return self._background_offset
+        return self.params.background_offset
 
     @background_offset.setter
     def background_offset(self, new_value: float) -> None:
-        self._background_offset = new_value
+        self.params.background_offset = float(new_value)
         self._calculate_img_data()
         self.img_changed.emit()
+
+    @property
+    def file_iteration_mode(self) -> str:
+        return self.params.file_iteration_mode
+
+    @file_iteration_mode.setter
+    def file_iteration_mode(self, new_mode: str) -> None:
+        self.params.file_iteration_mode = new_mode
 
     def load_series_img(self, pos: int) -> None:
         """
@@ -534,8 +539,8 @@ class ImgModel:
         # calculate the current _img_data
         if self._background_data is not None and not self._img_corrections.has_items():
             self._img_data_background_subtracted = self._img_data - (
-                self._background_scaling * self._background_data
-                + self._background_offset
+                self.params.background_scaling * self._background_data
+                + self.params.background_offset
             )
         elif self._background_data is None and self._img_corrections.has_items():
             self._img_data_absorption_corrected = (
@@ -546,8 +551,8 @@ class ImgModel:
             self._img_data_background_subtracted_absorption_corrected = (
                 self._img_data
                 - (
-                    self._background_scaling * self._background_data
-                    + self._background_offset
+                    self.params.background_scaling * self._background_data
+                    + self.params.background_offset
                 )
             ) / self._img_corrections.get_data()
 
@@ -829,11 +834,11 @@ class ImgModel:
 
     @property
     def autoprocess(self) -> bool:
-        return self._autoprocess
+        return self.params.autoprocess
 
     @autoprocess.setter
     def autoprocess(self, new_val: bool) -> None:
-        self._autoprocess = new_val
+        self.params.autoprocess = new_val
         if new_val:
             self._directory_watcher.activate()
         else:
@@ -841,11 +846,13 @@ class ImgModel:
 
     @property
     def factor(self) -> float:
-        return self._factor
+        return self.params.factor
 
     @factor.setter
     def factor(self, new_value: float) -> None:
-        self._factor = new_value
+        # float coercion: an integer factor would multiply integer-typed
+        # image data with wraparound (uint16 pixel values silently overflow)
+        self.params.factor = float(new_value)
         self.img_changed.emit()
 
     def get_img_data_float64(self) -> np.ndarray:

--- a/dioptas/model/state/__init__.py
+++ b/dioptas/model/state/__init__.py
@@ -8,7 +8,12 @@ parameters move out of the individual models into plain evented dataclasses
 instead of being serialized field-by-field in hand-written HDF5 code.
 """
 
-from .params import ConfigurationParams, ViewParams, default_working_directories
+from .params import (
+    ConfigurationParams,
+    ImgParams,
+    ViewParams,
+    default_working_directories,
+)
 from .hdf5 import (
     save_params,
     load_params,
@@ -21,6 +26,7 @@ from .derived import Derived
 
 __all__ = [
     "ConfigurationParams",
+    "ImgParams",
     "ViewParams",
     "default_working_directories",
     "save_params",

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -22,7 +22,12 @@ from typing import ClassVar
 
 from psygnal import SignalGroupDescriptor
 
-__all__ = ["ConfigurationParams", "ViewParams", "default_working_directories"]
+__all__ = [
+    "ConfigurationParams",
+    "ImgParams",
+    "ViewParams",
+    "default_working_directories",
+]
 
 
 def default_working_directories() -> dict[str, str]:
@@ -51,6 +56,32 @@ class ViewParams:
 
     #: what the integration image panel shows: "Image" or "Cake"
     img_mode: str = "Image"
+
+
+@dataclass
+class ImgParams:
+    """User-settable parameters of an ImgModel.
+
+    Owned by :class:`dioptas.model.ImgModel.ImgModel`, which exposes them
+    through delegating properties that add side effects (image
+    recalculation, directory-watcher activation). Writing the fields here
+    directly bypasses those side effects but still emits change events.
+    """
+
+    events: ClassVar[SignalGroupDescriptor] = SignalGroupDescriptor()
+
+    autoprocess: bool = False
+    #: int default is deliberate: it keeps pristine img_data in the image's
+    #: native dtype (uint16 * 1 stays uint16); any user-set factor is
+    #: coerced to float by ImgModel.factor so integer multiplication can
+    #: never wrap the pixel values
+    factor: float = 1
+
+    background_scaling: float = 1.0
+    background_offset: float = 0.0
+
+    #: how prev/next iterate through files: "number" or "time"
+    file_iteration_mode: str = "number"
 
 
 @dataclass

--- a/dioptas/model/util/integration.py
+++ b/dioptas/model/util/integration.py
@@ -32,7 +32,7 @@ def detect_fast_path(img_model: ImgModel) -> bool:
         not img_model.img_transformations
         and img_model._background_data is None
         and not img_model._img_corrections.has_items()
-        and img_model._factor == 1
+        and img_model.factor == 1
     )
 
 

--- a/dioptas/tests/controller_tests/test_BackgroundController.py
+++ b/dioptas/tests/controller_tests/test_BackgroundController.py
@@ -105,3 +105,13 @@ def test_save_fit_background_pattern(
     click_button(widget.qa_bkg_pattern_btn)
     click_button(widget.bkg_pattern_save_btn)
     assert os.path.exists(os.path.join(tmpdir, "test_bg.xy"))
+
+
+def test_bkg_image_spinboxes_react_to_params(background_controller, integration_widget, dioptas_model):
+    """Direct img-params writes render into the spinboxes via the namespaced
+    store events."""
+    dioptas_model.img_model.params.background_scaling = 2.5
+    assert integration_widget.bkg_image_scale_sb.value() == 2.5
+
+    dioptas_model.img_model.params.background_offset = -10.0
+    assert integration_widget.bkg_image_offset_sb.value() == -10.0

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -228,7 +228,9 @@ def test_setting_factors(dioptas_model):
     dioptas_model.img_model.load(os.path.join(data_path, "image_001.tif"))
     data1 = np.copy(dioptas_model.img_data)
     dioptas_model.img_model.factor = 2
-    assert np.array_equal(2 * data1, dioptas_model.img_data)
+    # 2.0: the reference must be computed in float — integer multiplication
+    # of the uint16 data would wrap around, which the factor no longer does
+    assert np.array_equal(2.0 * data1, dioptas_model.img_data)
 
 
 def test_iterate_next_image(dioptas_model):
@@ -743,3 +745,37 @@ def test_load_project_with_newer_format_version(dioptas_model, tmp_path):
 
     dioptas_model.load(filename)  # must not raise
     assert len(dioptas_model.configurations) == 1
+
+
+def test_img_params_forwarded_with_namespace(dioptas_model):
+    got = []
+    dioptas_model.configuration_params_changed.connect(
+        lambda field, new, old: got.append((field, new))
+    )
+    dioptas_model.img_model.params.factor = 2.0
+    assert got == [("img.factor", 2.0)]
+
+    dioptas_model.add_configuration()
+    inactive_img_model = dioptas_model.configurations[0].img_model
+    dioptas_model.select_configuration(1)
+    got.clear()
+
+    inactive_img_model.params.factor = 5.0
+    assert got == []  # non-selected configuration stays silent
+
+    dioptas_model.img_model.params.autoprocess = True
+    assert got == [("img.autoprocess", True)]
+
+
+def test_file_iteration_mode_round_trips_via_params(dioptas_model, tmp_path):
+    """ImgModel.file_iteration_mode is not in the legacy layout — it
+    round-trips via the generic img params group."""
+    dioptas_model.img_model.file_iteration_mode = "time"
+    filename = os.path.join(tmp_path, "iteration.dio")
+    dioptas_model.save(filename)
+
+    dioptas_model.reset()
+    assert dioptas_model.img_model.file_iteration_mode == "number"
+
+    dioptas_model.load(filename)
+    assert dioptas_model.img_model.file_iteration_mode == "time"

--- a/dioptas/tests/unit_tests/test_ImgModel.py
+++ b/dioptas/tests/unit_tests/test_ImgModel.py
@@ -310,3 +310,22 @@ def test_loading_karabo_file_without_extra_data(img_model):
         # Verify that other file types still work
         img_model.load(os.path.join(data_path, "image_001.tif"))
         assert img_model.img_data is not None
+
+
+def test_img_model_settings_delegate_to_params():
+    from dioptas.model.ImgModel import ImgModel
+
+    img_model = ImgModel()
+    emitted = []
+    img_model.img_changed.connect(lambda: emitted.append(1))
+
+    img_model.factor = 2.5
+    assert img_model.params.factor == 2.5
+    assert len(emitted) == 1  # property setter keeps its side effect
+
+    img_model.params.factor = 3.0  # direct params write: storage + event only
+    assert img_model.factor == 3.0
+    assert len(emitted) == 1
+
+    img_model.file_iteration_mode = "time"
+    assert img_model.params.file_iteration_mode == "time"

--- a/dioptas/tests/unit_tests/test_state.py
+++ b/dioptas/tests/unit_tests/test_state.py
@@ -258,3 +258,21 @@ def test_load_params_tolerates_corrupt_group(tmp_path):
 
     with h5py.File(filename, "r") as f:
         assert load_params(f, ConfigurationParams) is None
+
+
+# ---------------------------------------------------------------------------
+# ImgParams
+# ---------------------------------------------------------------------------
+
+from dioptas.model.state import ImgParams
+
+
+def test_img_params_defaults_and_events():
+    params = ImgParams()
+    assert params.factor == 1.0
+    assert params.file_iteration_mode == "number"
+
+    got = []
+    params.events.factor.connect(lambda new, old: got.append((new, old)))
+    params.factor = 2.0
+    assert got == [(2.0, 1.0)]


### PR DESCRIPTION
First follow-up on the merged state refactor (#228), applying the no-state-in-models direction to ImgModel.

## What moved

`ImgParams` (autoprocess, factor, background_scaling, background_offset, file_iteration_mode) is now the storage for ImgModel's settings; the model properties delegate while keeping their side effects (recalculation + `img_changed`, directory-watcher activation).

- **Persistence**: ImgParams saves generically inside the `image_model` group. `file_iteration_mode` was never in the legacy layout — it now survives project round trips (gap field, same pattern as `oned_azimuth_range` in #228).
- **Store surface**: img params changes arrive on `configuration_params_changed` namespaced as `img.<field>` (rewired on configuration switch). `Binder` gained an `event_field` override so bindings can react to namespaced fields.
- **Reactive demo**: BackgroundController's background image scale/offset spinboxes are now bindings — the hand-written handlers and configuration-switch value pushes are deleted, and direct params writes render into the GUI immediately (covered by test).

## Bugfix found along the way

Setting an **integer** intensity factor (scripts/tests; the GUI always sent floats) multiplied uint16 image data with silent wraparound — 65535 × 2 → 65534. The old `test_setting_factors` only passed because both sides of its assertion wrapped identically. The factor (and background scaling/offset) are now coerced to float; the pristine int default keeps unmodified images in their native dtype, so there is no memory/dtype regression for untouched images.

## Testing

Full suite: 1020 passed, 10 skipped. New tests: params delegation + side-effect split, namespaced forwarding (incl. non-selected configurations staying silent), file_iteration_mode round trip, reactive spinbox end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)