### PR TITLE
PatternModel settings to evented PatternParams state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ## Internal
 
 - ImgModel's settings (autoprocess, factor, background scaling/offset, file iteration mode) moved into an evented `ImgParams` dataclass following the no-state-in-models direction; the file iteration mode is now persisted in project files (previously lost on save); img params changes surface on `configuration_params_changed` with an `img.` prefix, and the background image scale/offset spinboxes bind reactively to them
+- PatternModel's settings (unit, file iteration mode) moved into an evented `PatternParams` dataclass, surfacing on `configuration_params_changed` with a `pattern.` prefix and saved generically in the project file's pattern group
 
 - the model Signal class is now backed by psygnal, gaining batched/paused emission while keeping the existing API
 - introduced an evented parameter dataclass layer (`dioptas.model.state`): Configuration settings now live in a `ConfigurationParams` object that is saved generically into project files; the 1D azimuth range and trim-trailing-zeros settings are now persisted (they were previously lost on save)

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -725,6 +725,7 @@ class Configuration:
             background_pattern_group.attrs["has_background_pattern"] = False
 
         pattern_group = f.create_group("pattern")
+        save_params(pattern_group, self.pattern_model.params)
         try:
             pattern_x = self.pattern_model.pattern._original_x
             pattern_y = self.pattern_model.pattern._original_y

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -373,6 +373,9 @@ class DioptasModel:
         self.img_model.params.events.disconnect(
             self._on_img_params_event, missing_ok=True
         )
+        self.pattern_model.params.events.disconnect(
+            self._on_pattern_params_event, missing_ok=True
+        )
 
     def connect_models(self) -> None:
         """Connects signals of the currently selected configuration."""
@@ -384,6 +387,7 @@ class DioptasModel:
             self._on_configuration_params_event
         )
         self.img_model.params.events.connect(self._on_img_params_event)
+        self.pattern_model.params.events.connect(self._on_pattern_params_event)
 
     def _on_configuration_params_event(self, info) -> None:
         """Forwards a psygnal EmissionInfo from the current configuration's
@@ -397,6 +401,12 @@ class DioptasModel:
     def _on_img_params_event(self, info) -> None:
         new, old = info.args
         self.configuration_params_changed.emit("img." + info.signal.name, new, old)
+
+    def _on_pattern_params_event(self, info) -> None:
+        new, old = info.args
+        self.configuration_params_changed.emit(
+            "pattern." + info.signal.name, new, old
+        )
 
     @property
     def working_directories(self) -> dict[str, str]:

--- a/dioptas/model/PatternModel.py
+++ b/dioptas/model/PatternModel.py
@@ -7,6 +7,7 @@ from xypattern import Pattern
 from xypattern.auto_background import SmoothBrucknerBackground
 
 from .util import Signal
+from .state import PatternParams
 from .util.HelperModule import FileNameIterator, get_base_name
 
 logger = logging.getLogger(__name__)
@@ -27,13 +28,31 @@ class PatternModel:
         self.pattern: Pattern = Pattern()
         self.pattern_filename: str = ""
 
-        self.unit: str = ""
-        self.file_iteration_mode: str = "number"
+        # All user-settable parameters live in the evented params dataclass;
+        # the properties below delegate to it.
+        self.params: PatternParams = PatternParams()
+
         self.file_name_iterator: FileNameIterator = FileNameIterator()
 
         self._background_pattern: Pattern | None = None
 
         self.pattern_changed: Signal = Signal()
+
+    @property
+    def unit(self) -> str:
+        return self.params.unit
+
+    @unit.setter
+    def unit(self, new_unit: str) -> None:
+        self.params.unit = new_unit
+
+    @property
+    def file_iteration_mode(self) -> str:
+        return self.params.file_iteration_mode
+
+    @file_iteration_mode.setter
+    def file_iteration_mode(self, new_mode: str) -> None:
+        self.params.file_iteration_mode = new_mode
 
     def set_pattern(
         self,

--- a/dioptas/model/state/__init__.py
+++ b/dioptas/model/state/__init__.py
@@ -11,6 +11,7 @@ instead of being serialized field-by-field in hand-written HDF5 code.
 from .params import (
     ConfigurationParams,
     ImgParams,
+    PatternParams,
     ViewParams,
     default_working_directories,
 )
@@ -27,6 +28,7 @@ from .derived import Derived
 __all__ = [
     "ConfigurationParams",
     "ImgParams",
+    "PatternParams",
     "ViewParams",
     "default_working_directories",
     "save_params",

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -25,6 +25,7 @@ from psygnal import SignalGroupDescriptor
 __all__ = [
     "ConfigurationParams",
     "ImgParams",
+    "PatternParams",
     "ViewParams",
     "default_working_directories",
 ]
@@ -81,6 +82,24 @@ class ImgParams:
     background_offset: float = 0.0
 
     #: how prev/next iterate through files: "number" or "time"
+    file_iteration_mode: str = "number"
+
+
+@dataclass
+class PatternParams:
+    """User-settable parameters of a PatternModel.
+
+    Owned by :class:`dioptas.model.PatternModel.PatternModel`; the model's
+    properties delegate here. Writing fields directly bypasses model side
+    effects but still emits change events.
+    """
+
+    events: ClassVar[SignalGroupDescriptor] = SignalGroupDescriptor()
+
+    #: unit of the current pattern's x-axis ("", "2th_deg", "q_A^-1", "d_A")
+    unit: str = ""
+
+    #: how prev/next iterate through pattern files: "number" or "time"
     file_iteration_mode: str = "number"
 
 

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -779,3 +779,22 @@ def test_file_iteration_mode_round_trips_via_params(dioptas_model, tmp_path):
 
     dioptas_model.load(filename)
     assert dioptas_model.img_model.file_iteration_mode == "time"
+
+
+def test_pattern_model_settings_delegate_to_params(dioptas_model):
+    pattern_model = dioptas_model.pattern_model
+    pattern_model.unit = "2th_deg"
+    assert pattern_model.params.unit == "2th_deg"
+
+    pattern_model.set_file_iteration_mode("time")
+    assert pattern_model.params.file_iteration_mode == "time"
+    assert pattern_model.file_name_iterator.create_timed_file_list is True
+
+
+def test_pattern_params_forwarded_with_namespace(dioptas_model):
+    got = []
+    dioptas_model.configuration_params_changed.connect(
+        lambda field, new, old: got.append((field, new))
+    )
+    dioptas_model.pattern_model.params.file_iteration_mode = "time"
+    assert got == [("pattern.file_iteration_mode", "time")]

--- a/dioptas/tests/unit_tests/test_state.py
+++ b/dioptas/tests/unit_tests/test_state.py
@@ -276,3 +276,21 @@ def test_img_params_defaults_and_events():
     params.events.factor.connect(lambda new, old: got.append((new, old)))
     params.factor = 2.0
     assert got == [(2.0, 1.0)]
+
+
+# ---------------------------------------------------------------------------
+# PatternParams
+# ---------------------------------------------------------------------------
+
+from dioptas.model.state import PatternParams
+
+
+def test_pattern_params_defaults_and_events():
+    params = PatternParams()
+    assert params.unit == ""
+    assert params.file_iteration_mode == "number"
+
+    got = []
+    params.events.unit.connect(lambda new, old: got.append((new, old)))
+    params.unit = "q_A^-1"
+    assert got == [("q_A^-1", "")]


### PR DESCRIPTION
Second follow-up in the no-state-in-models series (after #229): PatternModel's user-settable state (`unit`, `file_iteration_mode`) moves into an evented `PatternParams` dataclass.

- Model properties delegate to the params storage; `set_file_iteration_mode` keeps its timed-file-list side effects.
- Changes surface on `DioptasModel.configuration_params_changed` namespaced as `pattern.<field>`, rewired on configuration switch like the `img.` namespace.
- The params document is saved generically in the project file's `pattern` group; both fields also remain in the legacy attributes, so no format compatibility change.

`PatternModel` now holds no settings of its own. Full suite: 1023 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)