### PR TITLE
MaskModel settings to evented MaskParams state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 
 - ImgModel's settings (autoprocess, factor, background scaling/offset, file iteration mode) moved into an evented `ImgParams` dataclass following the no-state-in-models direction; the file iteration mode is now persisted in project files (previously lost on save); img params changes surface on `configuration_params_changed` with an `img.` prefix, and the background image scale/offset spinboxes bind reactively to them
 - PatternModel's settings (unit, file iteration mode) moved into an evented `PatternParams` dataclass, surfacing on `configuration_params_changed` with a `pattern.` prefix and saved generically in the project file's pattern group
+- MaskModel's settings (drawing mode, ROI) moved into an evented `MaskParams` dataclass with a `mask.` prefix on the store surface; the mask/unmask drawing mode is now persisted in project files (previously lost on save)
 
 - the model Signal class is now backed by psygnal, gaining batched/paused emission while keeping the existing API
 - introduced an evented parameter dataclass layer (`dioptas.model.state`): Configuration settings now live in a `ConfigurationParams` object that is saved generically into project files; the 1D azimuth range and trim-trailing-zeros settings are now persisted (they were previously lost on save)

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -13,7 +13,14 @@ from xypattern import Pattern
 from xypattern.auto_background import SmoothBrucknerBackground
 
 from .util import Signal
-from .state import ConfigurationParams, ImgParams, save_params, load_params, Derived
+from .state import (
+    ConfigurationParams,
+    ImgParams,
+    MaskParams,
+    save_params,
+    load_params,
+    Derived,
+)
 from .util.ImgCorrection import (
     CbnCorrection,
     ObliqueAngleDetectorAbsorptionCorrection,
@@ -648,6 +655,7 @@ class Configuration:
 
         # save mask model (only user-drawn mask, not plugin-generated masks)
         mask_group = f.create_group("mask")
+        save_params(mask_group, self.mask_model.params)
         current_mask = self.mask_model.get_img()
         mask_data = mask_group.create_dataset("data", current_mask.shape, dtype=bool)
         mask_data[...] = current_mask
@@ -1094,6 +1102,10 @@ class Configuration:
             self.img_model.params.file_iteration_mode = (
                 saved_img_params.file_iteration_mode
             )
+
+        saved_mask_params = load_params(f.get("mask"), MaskParams)
+        if saved_mask_params is not None:
+            self.mask_model.params.mode = saved_mask_params.mode
 
         if self.calibration_model.is_calibrated:
             self.integrate_image_1d()

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -376,6 +376,9 @@ class DioptasModel:
         self.pattern_model.params.events.disconnect(
             self._on_pattern_params_event, missing_ok=True
         )
+        self.mask_model.params.events.disconnect(
+            self._on_mask_params_event, missing_ok=True
+        )
 
     def connect_models(self) -> None:
         """Connects signals of the currently selected configuration."""
@@ -388,6 +391,7 @@ class DioptasModel:
         )
         self.img_model.params.events.connect(self._on_img_params_event)
         self.pattern_model.params.events.connect(self._on_pattern_params_event)
+        self.mask_model.params.events.connect(self._on_mask_params_event)
 
     def _on_configuration_params_event(self, info) -> None:
         """Forwards a psygnal EmissionInfo from the current configuration's
@@ -407,6 +411,10 @@ class DioptasModel:
         self.configuration_params_changed.emit(
             "pattern." + info.signal.name, new, old
         )
+
+    def _on_mask_params_event(self, info) -> None:
+        new, old = info.args
+        self.configuration_params_changed.emit("mask." + info.signal.name, new, old)
 
     @property
     def working_directories(self) -> dict[str, str]:

--- a/dioptas/model/MaskModel.py
+++ b/dioptas/model/MaskModel.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from .util.cosmics import cosmicsimage
 from .util import Signal
+from .state import MaskParams
 from .util.point import Point
 
 logger = logging.getLogger(__name__)
@@ -20,11 +21,13 @@ logger = logging.getLogger(__name__)
 
 class MaskModel:
     def __init__(self, mask_dimension: tuple[int, int] = (2048, 2048)) -> None:
+        # All user-settable parameters live in the evented params dataclass;
+        # the properties below delegate to it.
+        self.params: MaskParams = MaskParams()
+
         self.mask_dimension: tuple[int, int] = mask_dimension
         self.reset_dimension()
         self.filename: str = ''
-        self.mode: bool = True
-        self.roi: tuple[int, int, int, int] | None = None
 
         self._mask_data: np.ndarray = np.zeros(self.mask_dimension, dtype=bool)
         self._undo_deque: deque[np.ndarray] = deque(maxlen=50)
@@ -37,6 +40,22 @@ class MaskModel:
         self.mask_changed: Signal = Signal()
 
         self.mask_plugin_manager = None  # set by Configuration
+
+    @property
+    def mode(self) -> bool:
+        return self.params.mode
+
+    @mode.setter
+    def mode(self, new_mode: bool) -> None:
+        self.params.mode = new_mode
+
+    @property
+    def roi(self) -> tuple[int, int, int, int] | None:
+        return self.params.roi
+
+    @roi.setter
+    def roi(self, new_roi: tuple[int, int, int, int] | None) -> None:
+        self.params.roi = new_roi
 
     def set_dimension(self, mask_dimension: tuple[int, int]) -> None:
         if not np.array_equal(mask_dimension, self.mask_dimension):

--- a/dioptas/model/state/__init__.py
+++ b/dioptas/model/state/__init__.py
@@ -11,6 +11,7 @@ instead of being serialized field-by-field in hand-written HDF5 code.
 from .params import (
     ConfigurationParams,
     ImgParams,
+    MaskParams,
     PatternParams,
     ViewParams,
     default_working_directories,
@@ -28,6 +29,7 @@ from .derived import Derived
 __all__ = [
     "ConfigurationParams",
     "ImgParams",
+    "MaskParams",
     "PatternParams",
     "ViewParams",
     "default_working_directories",

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -25,6 +25,7 @@ from psygnal import SignalGroupDescriptor
 __all__ = [
     "ConfigurationParams",
     "ImgParams",
+    "MaskParams",
     "PatternParams",
     "ViewParams",
     "default_working_directories",
@@ -83,6 +84,23 @@ class ImgParams:
 
     #: how prev/next iterate through files: "number" or "time"
     file_iteration_mode: str = "number"
+
+
+@dataclass
+class MaskParams:
+    """User-settable parameters of a MaskModel.
+
+    Owned by :class:`dioptas.model.MaskModel.MaskModel`; the model's
+    properties delegate here.
+    """
+
+    events: ClassVar[SignalGroupDescriptor] = SignalGroupDescriptor()
+
+    #: drawing mode: True masks, False unmasks
+    mode: bool = True
+
+    #: rectangular region of interest as (x1, x2, y1, y2); None = disabled
+    roi: tuple[int, int, int, int] | None = None
 
 
 @dataclass

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -798,3 +798,36 @@ def test_pattern_params_forwarded_with_namespace(dioptas_model):
     )
     dioptas_model.pattern_model.params.file_iteration_mode = "time"
     assert got == [("pattern.file_iteration_mode", "time")]
+
+
+def test_mask_model_settings_delegate_to_params(dioptas_model):
+    mask_model = dioptas_model.mask_model
+    mask_model.set_mode(False)
+    assert mask_model.params.mode is False
+
+    dioptas_model.current_configuration.roi = (10, 100, 20, 200)
+    assert mask_model.params.roi == (10, 100, 20, 200)
+    assert mask_model.roi_mask is not None
+
+
+def test_mask_params_forwarded_with_namespace(dioptas_model):
+    got = []
+    dioptas_model.configuration_params_changed.connect(
+        lambda field, new, old: got.append((field, new))
+    )
+    dioptas_model.mask_model.params.mode = False
+    assert got == [("mask.mode", False)]
+
+
+def test_mask_mode_round_trips_via_params(dioptas_model, tmp_path):
+    """MaskModel.mode is not in the legacy layout — it round-trips via the
+    generic mask params group."""
+    dioptas_model.mask_model.set_mode(False)
+    filename = os.path.join(tmp_path, "mask_mode.dio")
+    dioptas_model.save(filename)
+
+    dioptas_model.reset()
+    assert dioptas_model.mask_model.mode is True
+
+    dioptas_model.load(filename)
+    assert dioptas_model.mask_model.mode is False

--- a/dioptas/tests/unit_tests/test_state.py
+++ b/dioptas/tests/unit_tests/test_state.py
@@ -294,3 +294,21 @@ def test_pattern_params_defaults_and_events():
     params.events.unit.connect(lambda new, old: got.append((new, old)))
     params.unit = "q_A^-1"
     assert got == [("q_A^-1", "")]
+
+
+# ---------------------------------------------------------------------------
+# MaskParams
+# ---------------------------------------------------------------------------
+
+from dioptas.model.state import MaskParams
+
+
+def test_mask_params_defaults_and_events():
+    params = MaskParams()
+    assert params.mode is True
+    assert params.roi is None
+
+    got = []
+    params.events.mode.connect(lambda new, old: got.append((new, old)))
+    params.mode = False
+    assert got == [(False, True)]


### PR DESCRIPTION
Third follow-up in the no-state-in-models series (after #229, #230): MaskModel's user-settable state moves into an evented `MaskParams` dataclass.

- `mode` (mask vs unmask drawing mode) and `roi` become params-backed delegating properties; `MaskModel` now holds no settings of its own.
- Changes surface on `configuration_params_changed` namespaced as `mask.<field>`.
- The params document saves generically in the `mask` group. The drawing mode was never in the legacy layout — it now survives project round trips (gap field). The ROI keeps its legacy persistence (image_model group) as the load driver, unchanged.

Full suite: 1027 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)