### PR TITLE
Uniform writes: setting side effects move into params event subscriptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ## Internal
 
+- settings writes are now uniform: side effects (re-integration, watcher activation, background recalculation, overlay pattern math) moved from property setters into params event subscriptions, so writing `params.<field>` directly behaves exactly like the property write for every writer (GUI, scripts, pipeline); the headless pipeline uses the hold() mechanism for its deliberately integration-free writes
+
 - ImgModel's settings (autoprocess, factor, background scaling/offset, file iteration mode) moved into an evented `ImgParams` dataclass following the no-state-in-models direction; the file iteration mode is now persisted in project files (previously lost on save); img params changes surface on `configuration_params_changed` with an `img.` prefix, and the background image scale/offset spinboxes bind reactively to them
 - PatternModel's settings (unit, file iteration mode) moved into an evented `PatternParams` dataclass, surfacing on `configuration_params_changed` with a `pattern.` prefix and saved generically in the project file's pattern group
 - MaskModel's settings (drawing mode, ROI) moved into an evented `MaskParams` dataclass with a `mask.` prefix on the store surface; the mask/unmask drawing mode is now persisted in project files (previously lost on save)

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -104,6 +104,52 @@ class Configuration:
             active=self.params.auto_integrate_cake,
         )
 
+        # side effects of settings changes live here (not in the property
+        # setters), so a direct params write behaves exactly like the
+        # property write — no matter who writes (GUI, script, pipeline).
+        # Subscribed before DioptasModel's store forwarding, so reactions
+        # run before the GUI is notified.
+        self.params.events.connect(self._on_own_params_changed)
+        self.calibration_model.params.events.connect(
+            self._on_calibration_params_changed
+        )
+
+    def _on_own_params_changed(self, info) -> None:
+        field = info.signal.name
+        if field == "integration_rad_points":
+            self.pattern_integration.recompute()
+            self.cake_integration.invalidate()
+        elif field in ("cake_azimuth_points", "cake_azimuth_range"):
+            self.cake_integration.invalidate()
+        elif field == "oned_azimuth_range":
+            self.pattern_integration.invalidate()
+        elif field == "integration_unit":
+            new_unit, old_unit = info.args
+            self._on_integration_unit_changed(new_unit, old_unit)
+        elif field == "auto_integrate_pattern":
+            self.pattern_integration.active = info.args[0]
+        elif field == "auto_integrate_cake":
+            self.cake_integration.active = info.args[0]
+
+    def _on_calibration_params_changed(self, info) -> None:
+        if info.signal.name == "correct_solid_angle":
+            self.pattern_integration.invalidate()
+            self.cake_integration.invalidate()
+
+    def _on_integration_unit_changed(self, new_unit: str, old_unit: str) -> None:
+        pattern = self.pattern_model.pattern
+        x = getattr(pattern, "x", None)
+        valid_units = {"2th_deg", "q_A^-1", "d_A"}
+        if old_unit not in valid_units or new_unit not in valid_units:
+            return
+        if x is not None and len(x) > 1:
+            pattern.transform_x(
+                lambda x: convert_units(
+                    x, self.calibration_model.wavelength, old_unit, new_unit
+                )
+            )
+            self.pattern_integration.recompute()
+
     def _connect_signals(self) -> None:
         """Connects the img_changed signal to responding functions."""
         self.img_model.img_changed.connect(self.update_mask_dimension)
@@ -401,8 +447,6 @@ class Configuration:
     @integration_rad_points.setter
     def integration_rad_points(self, new_value: int | None) -> None:
         self.params.integration_rad_points = new_value
-        self.pattern_integration.recompute()
-        self.cake_integration.invalidate()
 
     @property
     def cake_azimuth_points(self) -> int:
@@ -411,7 +455,6 @@ class Configuration:
     @cake_azimuth_points.setter
     def cake_azimuth_points(self, new_value: int) -> None:
         self.params.cake_azimuth_points = new_value
-        self.cake_integration.invalidate()
 
     @property
     def cake_azimuth_range(self) -> list[float] | None:
@@ -420,7 +463,6 @@ class Configuration:
     @cake_azimuth_range.setter
     def cake_azimuth_range(self, new_value: list[float] | None) -> None:
         self.params.cake_azimuth_range = new_value
-        self.cake_integration.invalidate()
 
     @property
     def oned_azimuth_range(self) -> list[float] | None:
@@ -429,7 +471,6 @@ class Configuration:
     @oned_azimuth_range.setter
     def oned_azimuth_range(self, new_value: list[float] | None) -> None:
         self.params.oned_azimuth_range = new_value
-        self.pattern_integration.invalidate()
 
     @property
     def integration_unit(self) -> str:
@@ -437,23 +478,7 @@ class Configuration:
 
     @integration_unit.setter
     def integration_unit(self, new_unit: str) -> None:
-        old_unit = self.integration_unit
         self.params.integration_unit = new_unit
-
-        pattern = self.pattern_model.pattern
-        x = getattr(pattern, "x", None)
-        valid_units = {"2th_deg", "q_A^-1", "d_A"}
-        if old_unit not in valid_units or new_unit not in valid_units:
-            return
-        if old_unit == new_unit:
-            return
-        if x is not None and len(x) > 1:
-            pattern.transform_x(
-                lambda x: convert_units(
-                    x, self.calibration_model.wavelength, old_unit, new_unit
-                )
-            )
-            self.pattern_integration.recompute()
 
     @property
     def correct_solid_angle(self) -> bool:
@@ -462,8 +487,6 @@ class Configuration:
     @correct_solid_angle.setter
     def correct_solid_angle(self, new_val: bool) -> None:
         self.calibration_model.correct_solid_angle = new_val
-        self.pattern_integration.invalidate()
-        self.cake_integration.invalidate()
 
     @property
     def is_calibrated(self) -> bool:
@@ -476,7 +499,6 @@ class Configuration:
     @auto_integrate_cake.setter
     def auto_integrate_cake(self, new_value: bool) -> None:
         self.params.auto_integrate_cake = new_value
-        self.cake_integration.active = new_value
 
     @property
     def auto_integrate_pattern(self) -> bool:
@@ -485,7 +507,6 @@ class Configuration:
     @auto_integrate_pattern.setter
     def auto_integrate_pattern(self, new_value: bool) -> None:
         self.params.auto_integrate_pattern = new_value
-        self.pattern_integration.active = new_value
 
     @property
     def cake_img(self) -> np.ndarray:

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -907,6 +907,10 @@ class Configuration:
         self.img_model.autoprocess = f.get("image_model").attrs["auto_process"]
         self.img_model.autoprocess_changed.emit()
         self.img_model.factor = f.get("image_model").attrs["factor"]
+        # announce the restored image data explicitly (detector shape sync,
+        # plugin masks); historically this rode on the factor write above,
+        # which no longer emits when the value is unchanged
+        self.img_model.img_changed.emit()
 
         try:
             self.img_model.series_max = f.get("image_model").attrs["series_max"]

--- a/dioptas/model/ImgModel.py
+++ b/dioptas/model/ImgModel.py
@@ -150,6 +150,29 @@ class ImgModel:
 
         self.transformations_changed.connect(self._update_correction_transformations)
 
+        # side effects of settings changes live here (not in the property
+        # setters), so a direct params write behaves exactly like the
+        # property write
+        self.params.events.connect(self._on_params_changed)
+
+    def _on_params_changed(self, info) -> None:
+        field = info.signal.name
+        if field in ("factor", "background_scaling", "background_offset"):
+            # normalize storage to float: an integer factor/scaling would
+            # multiply integer-typed image data with wraparound. psygnal
+            # updates storage on equal-compare writes without re-emitting.
+            value = info.args[0]
+            if not isinstance(value, float):
+                setattr(self.params, field, float(value))
+            if field != "factor":
+                self._calculate_img_data()
+            self.img_changed.emit()
+        elif field == "autoprocess":
+            if info.args[0]:
+                self._directory_watcher.activate()
+            else:
+                self._directory_watcher.deactivate()
+
     def load(self, filename: str, pos: int = 0) -> None:
         """
         Loads an image file in any format known by fabIO, PIL or HDF5. Automatically performs all previous img
@@ -413,9 +436,7 @@ class ImgModel:
 
     @background_scaling.setter
     def background_scaling(self, new_value: float) -> None:
-        self.params.background_scaling = float(new_value)
-        self._calculate_img_data()
-        self.img_changed.emit()
+        self.params.background_scaling = new_value
 
     @property
     def background_offset(self) -> float:
@@ -423,9 +444,7 @@ class ImgModel:
 
     @background_offset.setter
     def background_offset(self, new_value: float) -> None:
-        self.params.background_offset = float(new_value)
-        self._calculate_img_data()
-        self.img_changed.emit()
+        self.params.background_offset = new_value
 
     @property
     def img_transformations(self) -> list[Callable[[np.ndarray], np.ndarray]]:
@@ -865,10 +884,6 @@ class ImgModel:
     @autoprocess.setter
     def autoprocess(self, new_val: bool) -> None:
         self.params.autoprocess = new_val
-        if new_val:
-            self._directory_watcher.activate()
-        else:
-            self._directory_watcher.deactivate()
 
     @property
     def factor(self) -> float:
@@ -876,10 +891,7 @@ class ImgModel:
 
     @factor.setter
     def factor(self, new_value: float) -> None:
-        # float coercion: an integer factor would multiply integer-typed
-        # image data with wraparound (uint16 pixel values silently overflow)
-        self.params.factor = float(new_value)
-        self.img_changed.emit()
+        self.params.factor = new_value
 
     def get_img_data_float64(self) -> np.ndarray:
         """Return current image data as a contiguous float64 array.

--- a/dioptas/model/OverlayModel.py
+++ b/dioptas/model/OverlayModel.py
@@ -38,6 +38,21 @@ class Overlay(Pattern):
             offset=Pattern.offset.fget(self),
         )
         Overlay.index += 1
+        # scaling/offset reactions push into the Pattern base class, so a
+        # direct params write behaves exactly like the property write
+        self.params.events.connect(self._on_params_changed)
+
+    def _on_params_changed(self, info) -> None:
+        field = info.signal.name
+        if field == "scaling":
+            Pattern.scaling.fset(self, info.args[0])
+            effective = Pattern.scaling.fget(self)
+            if effective != info.args[0]:
+                # xypattern clamped the value — record the effective one
+                # (this re-emits once with the corrected value)
+                self.params.scaling = effective
+        elif field == "offset":
+            Pattern.offset.fset(self, info.args[0])
 
     @classmethod
     def from_pattern(cls, pattern: Pattern) -> Overlay:
@@ -81,10 +96,10 @@ class Overlay(Pattern):
 
     @scaling.setter
     def scaling(self, value: float) -> None:
-        Pattern.scaling.fset(self, value)
         if "params" in self.__dict__:
-            # record the effective (possibly clamped) value
-            self.params.scaling = Pattern.scaling.fget(self)
+            self.params.scaling = value
+        else:  # during super().__init__, before params exists
+            Pattern.scaling.fset(self, value)
 
     @property
     def offset(self) -> float:
@@ -92,9 +107,10 @@ class Overlay(Pattern):
 
     @offset.setter
     def offset(self, value: float) -> None:
-        Pattern.offset.fset(self, value)
         if "params" in self.__dict__:
-            self.params.offset = Pattern.offset.fget(self)
+            self.params.offset = value
+        else:
+            Pattern.offset.fset(self, value)
 
 
 class OverlayModel:

--- a/dioptas/pipeline.py
+++ b/dioptas/pipeline.py
@@ -469,9 +469,10 @@ class Pipeline:
 
     @integration_unit.setter
     def integration_unit(self, unit: str) -> None:
-        # write to params directly: skips the Configuration property's
-        # axis-transformation/re-integration side effects
-        self._configuration.params.integration_unit = unit
+        # the pipeline integrates explicitly — suppress the write's
+        # re-integration reaction
+        with self._configuration.pattern_integration.hold(flush=False):
+            self._configuration.params.integration_unit = unit
 
     @property
     def integration_num_points(self):
@@ -480,7 +481,8 @@ class Pipeline:
 
     @integration_num_points.setter
     def integration_num_points(self, n) -> None:
-        self._configuration.params.integration_rad_points = n
+        with self._configuration.pattern_integration.hold(flush=False):
+            self._configuration.params.integration_rad_points = n
 
     @property
     def azimuth_range(self):
@@ -489,7 +491,8 @@ class Pipeline:
 
     @azimuth_range.setter
     def azimuth_range(self, range) -> None:
-        self._configuration.params.oned_azimuth_range = range
+        with self._configuration.pattern_integration.hold(flush=False):
+            self._configuration.params.oned_azimuth_range = range
 
     @property
     def correct_solid_angle(self) -> bool:

--- a/dioptas/tests/unit_tests/test_ImgModel.py
+++ b/dioptas/tests/unit_tests/test_ImgModel.py
@@ -323,9 +323,9 @@ def test_img_model_settings_delegate_to_params():
     assert img_model.params.factor == 2.5
     assert len(emitted) == 1  # property setter keeps its side effect
 
-    img_model.params.factor = 3.0  # direct params write: storage + event only
+    img_model.params.factor = 3.0  # direct write behaves like the property
     assert img_model.factor == 3.0
-    assert len(emitted) == 1
+    assert len(emitted) == 2
 
     img_model.file_iteration_mode = "time"
     assert img_model.params.file_iteration_mode == "time"
@@ -354,3 +354,26 @@ def test_transformations_are_canonical_in_params():
 
     img_model.load_transformations_string_list(["not_a_transformation"])
     assert img_model.params.transformations == []
+
+
+def test_direct_img_params_writes_trigger_same_reactions():
+    """Uniform writes: direct params writes behave like property writes."""
+    from dioptas.model.ImgModel import ImgModel
+
+    img_model = ImgModel()
+    emitted = []
+    img_model.img_changed.connect(lambda: emitted.append(1))
+
+    img_model.params.factor = 2  # int, direct write
+    assert len(emitted) == 1
+    assert isinstance(img_model.params.factor, float)  # coerced in reaction
+
+    img_model.params.background_scaling = 3
+    assert len(emitted) == 2
+    assert isinstance(img_model.params.background_scaling, float)
+
+    img_model.params.autoprocess = True
+    assert img_model._directory_watcher._active if hasattr(
+        img_model._directory_watcher, "_active"
+    ) else True
+    img_model.params.autoprocess = False

--- a/dioptas/tests/unit_tests/test_OverlayModel.py
+++ b/dioptas/tests/unit_tests/test_OverlayModel.py
@@ -281,3 +281,20 @@ def test_phase_item_params_backed_lists():
     assert phase_model.item_params[0].visible is False
     assert phase_model.phase_colors[0] == (1, 2, 3)
     assert phase_model.phase_visible[0] is False
+
+
+def test_direct_overlay_params_writes_reach_pattern_math():
+    """Uniform writes: direct params writes update the Pattern computation."""
+    import numpy as np
+    from dioptas.model.OverlayModel import OverlayModel
+
+    overlay_model = OverlayModel()
+    overlay = overlay_model.add_overlay(np.linspace(0, 10), np.ones(50), "ov")
+
+    overlay.params.scaling = 3.0
+    overlay.params.offset = 1.0
+    _, y = overlay.data
+    assert y[0] == 3.0 * 1.0 + 1.0
+
+    overlay.params.scaling = -2.0  # clamped by xypattern
+    assert overlay.params.scaling == 0.0

--- a/dioptas/tests/unit_tests/test_configuration.py
+++ b/dioptas/tests/unit_tests/test_configuration.py
@@ -377,3 +377,24 @@ def test_working_directories_passed_by_reference():
     directories = {"image": "/somewhere"}
     config = Configuration(directories)
     assert config.working_directories is directories
+
+
+def test_direct_params_writes_trigger_same_reactions_as_properties():
+    """Uniform writes: a direct params write behaves like the property write."""
+    from unittest.mock import MagicMock
+
+    config = Configuration()
+    config.pattern_integration.recompute = MagicMock()
+    config.cake_integration.invalidate = MagicMock()
+
+    config.params.integration_rad_points = 1500
+    config.pattern_integration.recompute.assert_called_once()
+    config.cake_integration.invalidate.assert_called_once()
+
+    config.params.auto_integrate_cake = True
+    assert config.cake_integration.active is True
+    config.params.auto_integrate_pattern = False
+    assert config.pattern_integration.active is False
+
+    config.calibration_model.params.correct_solid_angle = False
+    config.cake_integration.invalidate.assert_called()


### PR DESCRIPTION
The closing refactor from the store-vs-models assessment: a direct `params.<field>` write now behaves exactly like the property write, for every writer (GUI, script, pipeline).

- **Configuration**: field→reaction map on its own params events (re-integration triggers, `auto_integrate_*` → `Derived.active`, integration-unit axis transformation using the event's `(new, old)`), plus solid-angle invalidation from the calibration params events. Reactions are subscribed before the store forwarding, so the GUI always observes post-reaction state.
- **ImgModel**: recalculation/`img_changed` and the directory-watcher toggle in subscriptions; float coercion happens in the reaction via an equal-compare re-store (psygnal updates storage without re-emitting).
- **Overlay**: scaling/offset push into the `xypattern.Pattern` math from the subscription, recording clamped values back.
- **Pipeline** keeps its integration-free writes through the uniform `hold(flush=False)` mechanism instead of relying on params writes bypassing reactions.
- One accidental dependency surfaced: the project loader relied on the factor setter's unconditional `img_changed` emission (now suppressed for unchanged values) to sync the detector shape — the loader now emits explicitly with a comment.

Property setters are now pure delegation; deleting the redundant shims where nothing needs them is the follow-up. Full suite: 1045 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)