### PR TITLE
State cleanups: generic Configuration.copy(), remaining view state into ViewParams

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
 
 ## Internal
 
+- `Configuration.copy()` now copies every setting generically instead of a hand-picked subset (it silently dropped the mask usage, integration unit, cake settings and auto-integrate flags)
+- the integration window layout mode, image dock state and overlay waterfall separation moved into the evented view state and are now saved in project files; the auto-create-pattern checkbox is bound to the persisted setting, so loading a project restores it (it previously always showed unchecked)
+
 - settings writes are now uniform: side effects (re-integration, watcher activation, background recalculation, overlay pattern math) moved from property setters into params event subscriptions, so writing `params.<field>` directly behaves exactly like the property write for every writer (GUI, scripts, pipeline); the headless pipeline uses the hold() mechanism for its deliberately integration-free writes
 
 - ImgModel's settings (autoprocess, factor, background scaling/offset, file iteration mode) moved into an evented `ImgParams` dataclass following the no-state-in-models direction; the file iteration mode is now persisted in project files (previously lost on save); img params changes surface on `configuration_params_changed` with an `img.` prefix, and the background image scale/offset spinboxes bind reactively to them

--- a/dioptas/controller/integration/BatchController.py
+++ b/dioptas/controller/integration/BatchController.py
@@ -1170,10 +1170,9 @@ class BatchController:
             self.model.overlay_model.add_overlay(
                 new_binning, data[i, x1:x2], f"{f_name}, {pos}"
             )
-        separation = (
-            self.widget.integration_control_widget.overlay_control_widget.waterfall_separation_msb.value()
+        self.model.overlay_model.overlay_waterfall(
+            self.model.view.waterfall_separation
         )
-        self.model.overlay_model.overlay_waterfall(separation)
 
     def load_single_image(self, x, y):
         """

--- a/dioptas/controller/integration/ImageController.py
+++ b/dioptas/controller/integration/ImageController.py
@@ -36,9 +36,10 @@ class ImageController:
 
         self.epics_controller = EpicsController(self.widget, self.model)
 
-        self.img_docked = True
-        self.view_mode = 'normal'  # modes available: normal, alternative
         self.roi_active = False
+        # which layout is currently applied to the widgets; distinct from
+        # the view_mode setting, which is what the user asked for
+        self._applied_view_mode = 'normal'
 
         self.vertical_splitter_alternative_state = None
         self.vertical_splitter_normal_state = None
@@ -186,6 +187,8 @@ class ImageController:
         self.widget.img_autoscale_btn.clicked.connect(self.img_autoscale_btn_clicked)
         self.widget.img_mode_btn.clicked.connect(self.change_view_mode)
         self.model.view.events.img_mode.connect(self._img_mode_changed)
+        self.model.view.events.view_mode.connect(self._view_mode_changed)
+        self.model.view.events.img_docked.connect(self._img_docked_changed)
 
         self.widget.integration_image_widget.show_background_subtracted_img_btn.clicked.connect(
             self.show_background_subtracted_img_btn_clicked)
@@ -312,7 +315,7 @@ class ImageController:
         self._tear_down_batch_processing()
 
     def _get_pattern_working_directory(self):
-        if self.widget.pattern_autocreate_cb.isChecked():
+        if self.model.current_configuration.auto_save_integrated_pattern:
             working_directory = self.model.working_directories['pattern']
         else:
             # if there is no working directory selected A file dialog opens up to choose a directory...
@@ -682,8 +685,10 @@ class ImageController:
             self.widget.img_widget.auto_level()
 
     def img_dock_btn_clicked(self):
-        self.img_docked = not self.img_docked
-        self.widget.dock_img(self.img_docked)
+        self.model.view.img_docked = not self.model.view.img_docked
+
+    def _img_docked_changed(self, docked, _old=None):
+        self.widget.dock_img(docked)
 
     def show_background_subtracted_img_btn_clicked(self):
         if self.model.view.img_mode == 'Image':
@@ -1070,13 +1075,19 @@ class ImageController:
                 self._update_image_mouse_click_pos()
 
     def change_view_btn_clicked(self):
-        if self.view_mode == 'alternative':
-            self.change_view_to_normal()
-        elif self.view_mode == 'normal':
+        if self.model.view.view_mode == 'alternative':
+            self.model.view.view_mode = 'normal'
+        else:
+            self.model.view.view_mode = 'alternative'
+
+    def _view_mode_changed(self, new_mode, _old_mode=None):
+        if new_mode == 'alternative':
             self.change_view_to_alternative()
+        else:
+            self.change_view_to_normal()
 
     def change_view_to_normal(self):
-        if self.view_mode == 'normal':
+        if self._applied_view_mode == 'normal':
             return
         self.vertical_splitter_alternative_state = self.widget.vertical_splitter.saveState()
         self.horizontal_splitter_alternative_state = self.widget.horizontal_splitter.saveState()
@@ -1090,12 +1101,12 @@ class ImageController:
             self.widget.horizontal_splitter.restoreState(self.horizontal_splitter_normal_state)
 
         self.widget.img_widget.set_orientation("horizontal")
-        self.view_mode = 'normal'
+        self._applied_view_mode = 'normal'
+        self.model.view.view_mode = 'normal'
 
     def change_view_to_alternative(self):
-        if self.view_mode == 'alternative':
+        if self._applied_view_mode == 'alternative':
             return
-
         self.vertical_splitter_normal_state = self.widget.vertical_splitter.saveState()
         self.horizontal_splitter_normal_state = self.widget.horizontal_splitter.saveState()
 
@@ -1109,4 +1120,5 @@ class ImageController:
             self.widget.horizontal_splitter.restoreState(self.horizontal_splitter_alternative_state)
 
         self.widget.img_widget.set_orientation("vertical")
-        self.view_mode = 'alternative'
+        self._applied_view_mode = 'alternative'
+        self.model.view.view_mode = 'alternative'

--- a/dioptas/controller/integration/PatternController.py
+++ b/dioptas/controller/integration/PatternController.py
@@ -12,6 +12,8 @@ from ...model.util.calc import convert_units
 from ...model.DioptasModel import DioptasModel
 from ...widgets.integration import IntegrationWidget
 
+from ..binding import Binder
+
 
 class PatternController:
     """
@@ -31,17 +33,18 @@ class PatternController:
 
         self.widget = widget
         self.model = dioptas_model
-
-        self.autocreate_pattern = False
+        self.binder = Binder(field_events=self.model.configuration_params_changed)
 
         self.create_subscriptions()
         self.create_gui_signals()
+        self.binder.refresh()
 
     def create_subscriptions(self):
         # Data subscriptions
         self.model.pattern_changed.connect(self.plot_pattern)
         self.model.configuration_selected.connect(self.update_gui)
         self.model.integration_unit_changed.connect(self._integration_unit_changed)
+        self.binder.connect_refresh(self.model.configuration_selected)
 
         # Gui subscriptions
         # self.widget.img_widget.roi.sigRegionChangeFinished.connect(self.image_changed)
@@ -55,7 +58,11 @@ class PatternController:
         """
 
         # file callbacks
-        self.widget.pattern_autocreate_cb.clicked.connect(self.autocreate_cb_changed)
+        self.binder.bind_checkbox(
+            self.widget.pattern_autocreate_cb,
+            lambda: self.model.current_configuration,
+            "auto_save_integrated_pattern",
+        )
         self.widget.pattern_load_btn.clicked.connect(self.load)
         self.widget.pattern_previous_btn.clicked.connect(self.load_previous)
         self.widget.pattern_next_btn.clicked.connect(self.load_next)
@@ -243,12 +250,6 @@ class PatternController:
         self.model.pattern_model.load_next_file(step=step)
         self.widget.pattern_filename_txt.setText(
             os.path.basename(self.model.pattern.filename)
-        )
-
-    def autocreate_cb_changed(self):
-        self.autocreate_pattern = self.widget.pattern_autocreate_cb.isChecked()
-        self.model.current_configuration.auto_save_integrated_pattern = (
-            self.widget.pattern_autocreate_cb.isChecked()
         )
 
     def filename_txt_changed(self):

--- a/dioptas/controller/integration/overlay/OverlayController.py
+++ b/dioptas/controller/integration/overlay/OverlayController.py
@@ -10,6 +10,8 @@ from ....widgets.UtilityWidgets import open_files_dialog
 from ....widgets.integration import IntegrationWidget
 from ....model.DioptasModel import DioptasModel
 
+from ...binding import Binder
+
 
 class OverlayController:
     """
@@ -27,7 +29,17 @@ class OverlayController:
         self.model = dioptas_model
 
         self.overlay_lw_items = []
+        self.binder = Binder()
         self.create_signals()
+        # the waterfall separation is a view setting, bound two-way so a
+        # loaded project restores the spinbox
+        self.binder.bind_spinbox(
+            self.overlay_widget.waterfall_separation_msb,
+            lambda: self.model.view,
+            "waterfall_separation",
+            dtype=float,
+        )
+        self.binder.refresh()
 
     def create_signals(self):
         self.connect_click_function(
@@ -270,8 +282,9 @@ class OverlayController:
         self.overlay_widget.show_cbs[ind].blockSignals(False)
 
     def waterfall_btn_click_callback(self):
-        separation = self.overlay_widget.waterfall_separation_msb.value()
-        self.model.overlay_model.overlay_waterfall(separation)
+        self.model.overlay_model.overlay_waterfall(
+            self.model.view.waterfall_separation
+        )
 
     def set_as_bkg_btn_click_callback(self):
         """

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -14,6 +14,7 @@ from xypattern.auto_background import SmoothBrucknerBackground
 
 from .util import Signal
 from .state import (
+    apply_params,
     CalibrationParams,
     ConfigurationParams,
     ImgParams,
@@ -522,16 +523,36 @@ class Configuration:
         self.pattern_integration.recompute()
 
     def copy(self) -> Configuration:
-        """Creates a copy of the current configuration."""
-        new_configuration = Configuration(self.working_directories)
-        new_configuration.img_model._img_data = self.img_model._img_data
-        new_configuration.img_model.img_transformations = deepcopy(
-            self.img_model.img_transformations
-        )
+        """Creates a copy of the current configuration.
 
-        new_configuration.calibration_model.set_pyFAI(
-            self.calibration_model.get_calibration_parameter()[0]
-        )
+        Every settings tree is copied generically, so settings added in the
+        future are included automatically."""
+        new_configuration = Configuration()
+
+        # suppressed while copying: the explicit integration below runs once
+        with new_configuration.pattern_integration.hold(
+            flush=False
+        ), new_configuration.cake_integration.hold(flush=False):
+            apply_params(new_configuration.params, self.params)
+            apply_params(new_configuration.img_model.params, self.img_model.params)
+            apply_params(new_configuration.mask_model.params, self.mask_model.params)
+            apply_params(
+                new_configuration.pattern_model.params, self.pattern_model.params
+            )
+            apply_params(
+                new_configuration.calibration_model.params,
+                self.calibration_model.params,
+            )
+
+            new_configuration.img_model._img_data = self.img_model._img_data
+
+            new_configuration.calibration_model.set_pyFAI(
+                self.calibration_model.get_calibration_parameter()[0]
+            )
+            # the copied supersampling factor only takes effect on the
+            # geometry when applied explicitly
+            new_configuration.calibration_model.set_supersampling()
+
         new_configuration.integrate_image_1d()
 
         return new_configuration

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -14,6 +14,7 @@ from xypattern import Pattern
 from .util import Signal
 from .util import jcpds
 from .state import (
+    apply_params,
     Derived,
     PhaseParams,
     ViewParams,
@@ -363,7 +364,7 @@ class DioptasModel:
         # subscribed controllers react through the change events
         saved_view = load_params(f, ViewParams, name="view")
         if saved_view is not None:
-            self.view.img_mode = saved_view.img_mode
+            apply_params(self.view, saved_view)
 
         f.close()
 

--- a/dioptas/model/state/__init__.py
+++ b/dioptas/model/state/__init__.py
@@ -9,6 +9,7 @@ instead of being serialized field-by-field in hand-written HDF5 code.
 """
 
 from .params import (
+    apply_params,
     CalibrationParams,
     ConfigurationParams,
     ImgParams,
@@ -32,6 +33,7 @@ from .hdf5 import (
 from .derived import Derived
 
 __all__ = [
+    "apply_params",
     "CalibrationParams",
     "ConfigurationParams",
     "ImgParams",

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -16,13 +16,16 @@ to know.
 
 from __future__ import annotations
 
+import copy as _copy
+import dataclasses
 import os
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from psygnal import SignalGroupDescriptor
 
 __all__ = [
+    "apply_params",
     "CalibrationParams",
     "ConfigurationParams",
     "ImgParams",
@@ -35,6 +38,23 @@ __all__ = [
     "ViewParams",
     "default_working_directories",
 ]
+
+
+def apply_params(target: Any, source: Any, fields: set[str] | None = None) -> None:
+    """Copies field values from *source* onto the existing *target* instance.
+
+    The target keeps its identity, so event subscriptions on it stay valid,
+    and every differing field emits its change event (and therefore runs
+    its reactions). Mutable values are deep-copied so the two instances do
+    not share state. Pass *fields* to restrict the copy to a subset.
+    """
+    for f in dataclasses.fields(target):
+        if fields is not None and f.name not in fields:
+            continue
+        value = getattr(source, f.name)
+        if isinstance(value, (dict, list, set)):
+            value = _copy.deepcopy(value)
+        setattr(target, f.name, value)
 
 
 def default_working_directories() -> dict[str, str]:

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -84,6 +84,15 @@ class ViewParams:
     #: what the integration image panel shows: "Image" or "Cake"
     img_mode: str = "Image"
 
+    #: integration window layout: "normal" or "alternative"
+    view_mode: str = "normal"
+
+    #: whether the image panel is docked in the main window
+    img_docked: bool = True
+
+    #: y separation applied by the overlay waterfall action
+    waterfall_separation: float = 100.0
+
 
 @dataclass
 class ImgParams:

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -915,3 +915,28 @@ def test_transformations_round_trip(dioptas_model, tmp_path):
     dioptas_model.reset()
     dioptas_model.load(filename)
     assert dioptas_model.img_model.params.transformations == ["rotate_matrix_m90"]
+
+
+def test_view_params_round_trip_all_fields(dioptas_model, tmp_path):
+    """Every view setting round-trips, applied onto the stable instance."""
+    dioptas_model.view.img_mode = "Cake"
+    dioptas_model.view.view_mode = "alternative"
+    dioptas_model.view.img_docked = False
+    dioptas_model.view.waterfall_separation = 42.0
+
+    filename = os.path.join(tmp_path, "view_all.dio")
+    dioptas_model.save(filename)
+
+    view_instance = dioptas_model.view
+    dioptas_model.reset()
+    dioptas_model.view.img_mode = "Image"
+    dioptas_model.view.view_mode = "normal"
+    dioptas_model.view.img_docked = True
+    dioptas_model.view.waterfall_separation = 100.0
+
+    dioptas_model.load(filename)
+    assert dioptas_model.view is view_instance
+    assert dioptas_model.view.img_mode == "Cake"
+    assert dioptas_model.view.view_mode == "alternative"
+    assert dioptas_model.view.img_docked is False
+    assert dioptas_model.view.waterfall_separation == 42.0

--- a/dioptas/tests/unit_tests/test_configuration.py
+++ b/dioptas/tests/unit_tests/test_configuration.py
@@ -398,3 +398,50 @@ def test_direct_params_writes_trigger_same_reactions_as_properties():
 
     config.calibration_model.params.correct_solid_angle = False
     config.cake_integration.invalidate.assert_called()
+
+
+def test_copy_carries_all_settings():
+    """copy() copies every settings tree generically, not a hand-picked subset."""
+    config = _load_calibrated_config()
+    config.use_mask = True
+    config.transparent_mask = True
+    config.integration_unit = "q_A^-1"
+    config.cake_azimuth_points = 720
+    config.params.oned_azimuth_range = [-90.0, 90.0]
+    config.img_model.params.factor = 3.0
+    config.mask_model.params.mode = False
+    config.calibration_model.params.polarization_factor = 0.5
+
+    copied = config.copy()
+
+    assert copied.use_mask is True
+    assert copied.transparent_mask is True
+    assert copied.integration_unit == "q_A^-1"
+    assert copied.cake_azimuth_points == 720
+    assert copied.oned_azimuth_range == [-90.0, 90.0]
+    assert copied.img_model.factor == 3.0
+    assert copied.mask_model.mode is False
+    assert copied.calibration_model.polarization_factor == 0.5
+
+
+def test_copy_does_not_share_mutable_settings():
+    config = _load_calibrated_config()
+    copied = config.copy()
+
+    copied.params.working_directories["image"] = "/copied/only"
+    assert config.working_directories["image"] != "/copied/only"
+
+
+def test_apply_params_preserves_instance_and_fires_events():
+    from dioptas.model.state import ConfigurationParams, apply_params
+
+    target = ConfigurationParams()
+    source = ConfigurationParams(use_mask=True, cake_azimuth_points=720)
+    got = []
+    target.events.use_mask.connect(lambda new, old: got.append(new))
+
+    apply_params(target, source)
+
+    assert target.use_mask is True
+    assert target.cake_azimuth_points == 720
+    assert got == [True]  # subscriptions on the target stayed valid


### PR DESCRIPTION
Two cleanups made cheap by the new architecture, from the post-refactor suggestion list.

## `Configuration.copy()` copies everything

`copy()` hand-copied working directories, image data, transformations and pyFAI geometry — silently dropping `use_mask`, `transparent_mask`, the integration unit, cake settings, auto-integrate flags and everything else, and it went stale whenever a settings field was added.

New `state.apply_params(target, source)` does a field-wise copy onto an existing params instance: the target keeps its identity (event subscriptions stay valid), each differing field fires its reaction, and mutable values are deep-copied so copies no longer share dicts. `copy()` applies every params tree under integration holds, so **settings added in future are included automatically**. The copied supersampling factor is now applied to the geometry, which the old copy never did.

## Remaining widget-owned view state

- `view_mode` / `img_docked` moved into `ViewParams`, applied reactively (buttons write state, subscriptions switch the layout) so the uniform-writes contract holds. Layout methods guard on an explicit `_applied_view_mode` render flag instead of the setting. Splitter states stay in the controller — they are QByteArray caches, not settings.
- Overlay **waterfall separation** is now a bound view setting; `BatchController` reads the state instead of reaching across into another tab's spinbox.
- `PatternController.autocreate_pattern` turned out to be **write-only dead state** (assigned twice, never read). Deleted rather than migrated; the real setting is `auto_save_integrated_pattern`, and the checkbox is now two-way bound to it — which **fixes a real bug**: the checkbox was never rendered from the model, so loading a project with auto-save enabled always showed it unchecked. `ImageController` now reads the setting rather than the checkbox.
- The loader applies saved view state via `apply_params`, so new view fields restore automatically.

`clicked_tth`/`clicked_azi` were deliberately left alone: 17 call sites behind dedicated signals, churn without benefit.

Also worth recording: **mass deletion of the delegation shims was assessed and dropped.** After the uniform-writes migration both spellings behave identically, so the ambiguity that motivated it is gone; deleting them would be a ~700-call-site rewrite with no behavioral benefit.

Full suite: 1049 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)