### PR TITLE
Auto-background settings as canonical params state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ## Internal
 
+- the automatic (smooth Bruckner) background settings — smoothing width, iterations, polynomial order and the fitted x-range — are now canonical evented state in `PatternParams` with the pattern model pushing them into the pattern computation, instead of living in spinboxes and inside xypattern's internals; project save/load no longer reaches into those internals, and the range restored from a project is no longer clamped against whichever pattern happens to be loaded at that moment
+
 - `Configuration.copy()` now copies every setting generically instead of a hand-picked subset (it silently dropped the mask usage, integration unit, cake settings and auto-integrate flags)
 - the integration window layout mode, image dock state and overlay waterfall separation moved into the evented view state and are now saved in project files; the auto-create-pattern checkbox is bound to the persisted setting, so loading a project restores it (it previously always showed unchecked)
 

--- a/dioptas/controller/integration/BackgroundController.py
+++ b/dioptas/controller/integration/BackgroundController.py
@@ -4,7 +4,6 @@ import os
 
 import numpy as np
 from qtpy import QtWidgets
-from xypattern.auto_background import SmoothBrucknerBackground
 
 from ...widgets.UtilityWidgets import open_file_dialog, save_file_dialog
 from ...widgets.integration import IntegrationWidget
@@ -182,25 +181,30 @@ class BackgroundController:
     def bkg_pattern_parameters_changed(self):
         bkg_pattern_parameters = self.background_widget.get_bkg_pattern_parameters()
         bkg_pattern_roi = self.background_widget.get_bkg_pattern_roi()
-        if self.model.pattern_model.pattern.auto_bkg is not None:
+        if self.model.pattern_model.params.auto_bkg_enabled:
             self.model.pattern_model.set_auto_background_subtraction(
                 bkg_pattern_parameters, bkg_pattern_roi
             )
 
     def update_bkg_gui_parameters(self):
-        pattern = self.model.pattern_model.pattern
-        auto_bkg = pattern.auto_bkg
-        if auto_bkg is None:
+        params = self.model.pattern_model.params
+        if not params.auto_bkg_enabled:
             return
 
-        assert type(auto_bkg) == SmoothBrucknerBackground
         self.background_widget.set_bkg_pattern_parameters(
-            [auto_bkg.smooth_width, auto_bkg.iterations, auto_bkg.cheb_order]
+            [
+                params.auto_bkg_smoothing,
+                params.auto_bkg_iterations,
+                params.auto_bkg_poly_order,
+            ]
         )
-        self.background_widget.set_bkg_pattern_roi(pattern.auto_bkg_roi)
+        roi = params.auto_bkg_roi
+        if roi is None:
+            return
+        self.background_widget.set_bkg_pattern_roi(roi)
 
         self.widget.pattern_widget.bkg_roi.blockSignals(True)
-        self.widget.pattern_widget.set_bkg_roi(*pattern.auto_bkg_roi)
+        self.widget.pattern_widget.set_bkg_roi(*roi)
         self.widget.pattern_widget.bkg_roi.blockSignals(False)
 
         if self.model.batch_model.binning is not None:
@@ -341,7 +345,7 @@ class BackgroundController:
         )
 
     def update_auto_pattern_bkg_widgets(self):
-        auto_bkg_enabled = self.model.pattern.auto_bkg is not None
+        auto_bkg_enabled = self.model.pattern_model.params.auto_bkg_enabled
         self._set_bkg_pattern_toggles(auto_bkg_enabled)
         self.widget.qa_bkg_pattern_inspect_btn.setVisible(auto_bkg_enabled)
 

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -10,7 +10,6 @@ import json
 from copy import deepcopy
 
 from xypattern import Pattern
-from xypattern.auto_background import SmoothBrucknerBackground
 
 from .util import Signal
 from .state import (
@@ -794,22 +793,23 @@ class Configuration:
         pattern_group.attrs["file_iteration_mode"] = (
             self.pattern_model.file_iteration_mode
         )
-        if self.pattern_model.pattern.auto_bkg:
+        pattern_params = self.pattern_model.params
+        if pattern_params.auto_bkg_enabled:
             pattern_group.attrs["auto_background_subtraction"] = True
             auto_background_group = pattern_group.create_group(
                 "auto_background_settings"
             )
-            auto_bkg = self.pattern_model.pattern.auto_bkg
+            auto_background_group.attrs["smoothing"] = pattern_params.auto_bkg_smoothing
+            auto_background_group.attrs["iterations"] = (
+                pattern_params.auto_bkg_iterations
+            )
+            auto_background_group.attrs["poly_order"] = (
+                pattern_params.auto_bkg_poly_order
+            )
 
-            if type(auto_bkg) == SmoothBrucknerBackground:
-                auto_background_group.attrs["smoothing"] = auto_bkg.smooth_width
-                auto_background_group.attrs["iterations"] = auto_bkg.iterations
-                auto_background_group.attrs["poly_order"] = auto_bkg.cheb_order
-
-            auto_bkg_roi = self.pattern_model.pattern.auto_bkg_roi
-            if auto_bkg_roi is not None:
-                auto_background_group.attrs["x_start"] = auto_bkg_roi[0]
-                auto_background_group.attrs["x_end"] = auto_bkg_roi[1]
+            if pattern_params.auto_bkg_roi is not None:
+                auto_background_group.attrs["x_start"] = pattern_params.auto_bkg_roi[0]
+                auto_background_group.attrs["x_end"] = pattern_params.auto_bkg_roi[1]
         else:
             pattern_group.attrs["auto_background_subtraction"] = False
 
@@ -1003,15 +1003,21 @@ class Configuration:
             )
 
         if f.get("pattern").attrs["auto_background_subtraction"]:
-            self.pattern_model.pattern.auto_bkg_roi = [
-                f.get("pattern").get("auto_background_settings").attrs["x_start"],
-                f.get("pattern").get("auto_background_settings").attrs["x_end"],
+            auto_background_group = f.get("pattern").get("auto_background_settings")
+            pattern_params = self.pattern_model.params
+            pattern_params.auto_bkg_smoothing = auto_background_group.attrs["smoothing"]
+            pattern_params.auto_bkg_iterations = auto_background_group.attrs[
+                "iterations"
             ]
-            self.pattern_model.pattern.auto_bkg = SmoothBrucknerBackground(
-                f.get("pattern").get("auto_background_settings").attrs["smoothing"],
-                f.get("pattern").get("auto_background_settings").attrs["iterations"],
-                f.get("pattern").get("auto_background_settings").attrs["poly_order"],
-            )
+            pattern_params.auto_bkg_poly_order = auto_background_group.attrs[
+                "poly_order"
+            ]
+            if "x_start" in auto_background_group.attrs:
+                pattern_params.auto_bkg_roi = [
+                    auto_background_group.attrs["x_start"],
+                    auto_background_group.attrs["x_end"],
+                ]
+            pattern_params.auto_bkg_enabled = True
 
         # load general configuration
         if f.get("general_information").attrs["integration_num_points"]:

--- a/dioptas/model/PatternModel.py
+++ b/dioptas/model/PatternModel.py
@@ -38,6 +38,63 @@ class PatternModel:
 
         self.pattern_changed: Signal = Signal()
 
+        self._applying_auto_bkg: bool = False
+
+        # the auto-background params are canonical; this reaction pushes
+        # them into the Pattern, which owns the computation, so a direct
+        # params write behaves exactly like set_auto_background_subtraction
+        self.params.events.connect(self._on_params_changed)
+
+    _AUTO_BKG_FIELDS = (
+        "auto_bkg_enabled",
+        "auto_bkg_smoothing",
+        "auto_bkg_iterations",
+        "auto_bkg_poly_order",
+        "auto_bkg_roi",
+    )
+
+    def _on_params_changed(self, info) -> None:
+        if info.signal.name in self._AUTO_BKG_FIELDS and not self._applying_auto_bkg:
+            self._apply_auto_background()
+
+    def _apply_auto_background(self) -> None:
+        """Applies the auto-background params to the pattern."""
+        if not self.params.auto_bkg_enabled:
+            self.pattern.auto_bkg = None
+            self.pattern_changed.emit()
+            return
+
+        roi = self.params.auto_bkg_roi
+        self.pattern.auto_bkg_roi = list(roi) if roi is not None else None
+        self.pattern.auto_bkg = SmoothBrucknerBackground(
+            self.params.auto_bkg_smoothing,
+            self.params.auto_bkg_iterations,
+            self.params.auto_bkg_poly_order,
+        )
+        self.pattern_changed.emit()
+
+    def _clamped_roi(self, roi: list[float] | None) -> list[float] | None:
+        """Keeps a user-supplied background roi inside the data range.
+
+        Only applied at the API boundary: a roi restored from a project file
+        must not be clamped against the pattern that happens to be loaded at
+        that moment."""
+        if roi is None:
+            return None
+        x, _ = self.pattern.original_data
+        if x is None or len(x) < 2:
+            return list(roi)
+
+        roi = list(roi)
+        if roi[0] > roi[1]:
+            roi[0], roi[1] = roi[1], roi[0]
+        x_step = x[1] - x[0]
+        roi[0] = roi[0] if roi[0] > x[0] else x[0] - x_step / 2
+        roi[0] = roi[0] if roi[0] < x[-1] - 1.5 * x_step else x[-1] - 1.5 * x_step
+        roi[1] = roi[1] if roi[1] < x[-1] else x[-1] + x_step / 2
+        roi[1] = roi[1] if roi[1] > x[0] + 1.5 * x_step else x[0] + 1.5 * x_step
+        return roi
+
     @property
     def unit(self) -> str:
         return self.params.unit
@@ -156,25 +213,22 @@ class PatternModel:
         roi is [x_min, x_max] specifying the range for background subtraction.
         """
         logger.info("Setting auto background subtraction with parameters: %s", parameters)
-        if roi is not None:
-            x, _ = self.pattern.original_data
-            roi = list(roi)
-
-            # make sure the roi is within the data range
-            if roi[0] > roi[1]:
-                roi[0], roi[1] = roi[1], roi[0]
-            x_step = x[1] - x[0]
-            roi[0] = roi[0] if roi[0] > x[0] else x[0] - x_step / 2
-            roi[0] = roi[0] if roi[0] < x[-1] - 1.5 * x_step else x[-1] - 1.5 * x_step
-            roi[1] = roi[1] if roi[1] < x[-1] else x[-1] + x_step / 2
-            roi[1] = roi[1] if roi[1] > x[0] + 1.5 * x_step else x[0] + 1.5 * x_step
-
-        self.pattern.auto_bkg_roi = roi
-        self.pattern.auto_bkg = SmoothBrucknerBackground(*parameters)
-        self.pattern_changed.emit()
+        # suppressed while writing, so the (expensive) background extraction
+        # runs once instead of once per field
+        self._applying_auto_bkg = True
+        try:
+            self.params.auto_bkg_smoothing = parameters[0]
+            self.params.auto_bkg_iterations = parameters[1]
+            self.params.auto_bkg_poly_order = parameters[2]
+            self.params.auto_bkg_roi = self._clamped_roi(roi)
+            self.params.auto_bkg_enabled = True
+        finally:
+            self._applying_auto_bkg = False
+        self._apply_auto_background()
 
     def unset_auto_background_subtraction(self) -> None:
         """Disables auto background extraction and removal."""
         logger.info("Unsetting auto background subtraction")
+        self.params.auto_bkg_enabled = False
         self.pattern.auto_bkg = None
         self.pattern_changed.emit()

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -254,6 +254,16 @@ class PatternParams:
     #: how prev/next iterate through pattern files: "number" or "time"
     file_iteration_mode: str = "number"
 
+    # Automatic (smooth Bruckner) background subtraction. These are the
+    # canonical values; PatternModel pushes them into the xypattern Pattern,
+    # which owns the actual computation.
+    auto_bkg_enabled: bool = False
+    auto_bkg_smoothing: float = 0.1
+    auto_bkg_iterations: int = 50
+    auto_bkg_poly_order: int = 50
+    #: [x_min, x_max] range the background is fitted over; None = full range
+    auto_bkg_roi: list[float] | None = None
+
 
 @dataclass
 class ConfigurationParams:

--- a/dioptas/tests/unit_tests/test_PatternModel.py
+++ b/dioptas/tests/unit_tests/test_PatternModel.py
@@ -209,3 +209,50 @@ def test_background_pattern_setter_clear(pattern_model: PatternModel):
     assert pattern_model.pattern.background_pattern is None
     _, y_data = pattern_model.pattern.data
     assert y_data == approx(np.ones(100) * 10)
+
+
+def test_auto_background_params_are_canonical():
+    """Direct auto-background params writes reach the pattern computation."""
+    import numpy as np
+    from dioptas.model.PatternModel import PatternModel
+
+    pattern_model = PatternModel()
+    pattern_model.set_pattern(np.linspace(1, 20, 200), np.ones(200) * 5)
+
+    pattern_model.params.auto_bkg_smoothing = 0.2
+    pattern_model.params.auto_bkg_iterations = 30
+    pattern_model.params.auto_bkg_poly_order = 20
+    pattern_model.params.auto_bkg_enabled = True
+
+    auto_bkg = pattern_model.pattern.auto_bkg
+    assert auto_bkg is not None
+    assert auto_bkg.smooth_width == 0.2
+    assert auto_bkg.iterations == 30
+    assert auto_bkg.cheb_order == 20
+
+    pattern_model.params.auto_bkg_enabled = False
+    assert pattern_model.pattern.auto_bkg is None
+
+
+def test_set_auto_background_subtraction_populates_params():
+    import numpy as np
+    from dioptas.model.PatternModel import PatternModel
+
+    pattern_model = PatternModel()
+    pattern_model.set_pattern(np.linspace(1, 20, 200), np.ones(200) * 5)
+    pattern_model.set_auto_background_subtraction([0.5, 40, 25], roi=[3.0, 15.0])
+
+    params = pattern_model.params
+    assert params.auto_bkg_enabled is True
+    assert params.auto_bkg_smoothing == 0.5
+    assert params.auto_bkg_iterations == 40
+    assert params.auto_bkg_poly_order == 25
+    assert params.auto_bkg_roi == [3.0, 15.0]
+
+    # user-supplied roi outside the data range is clamped at the API boundary
+    pattern_model.set_auto_background_subtraction([0.5, 40, 25], roi=[-100.0, 500.0])
+    assert params.auto_bkg_roi[0] >= 1.0 - 1.0
+    assert params.auto_bkg_roi[1] <= 20.0 + 1.0
+
+    pattern_model.unset_auto_background_subtraction()
+    assert params.auto_bkg_enabled is False


### PR DESCRIPTION
Task 4 from the post-refactor list: the smooth-Bruckner background settings (smoothing width, iterations, polynomial order, fitted x-range) were split between spinboxes and `xypattern`'s `Pattern.auto_bkg` object — which the project save code reached into with a `type(...) ==` check and private attributes.

They are now `PatternParams` fields, with a `PatternModel` reaction pushing them into the `Pattern` (which still owns the computation) — the same "params are canonical, the library object is the executor" shape used for `Overlay.scaling`. A direct params write therefore behaves exactly like `set_auto_background_subtraction()`.

- The multi-field write **batches into a single background extraction** instead of one per field (this computation is expensive).
- Save/load goes through the params; the `SmoothBrucknerBackground` import disappears from both `Configuration` and `BackgroundController`.
- `BackgroundController` renders from the params, dropping the `assert type(auto_bkg) == SmoothBrucknerBackground` and the `auto_bkg is not None` probing.

One deliberate design call, caught by the `test_with_q_and_fit_bg` round-trip test: **roi clamping stays at the API boundary** rather than moving into the reaction. Clamping validates user input against the current data range; applying it inside the reaction meant a range restored from a project file got clamped against whichever pattern happened to be loaded at that moment, truncating it (8.0 → 7.04).

Full suite: 1051 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)