### PR TITLE
Migrate remaining update_gui pushes to declarative bindings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ## Internal
 
+- the remaining hand-written `update_gui` pushes (mask transparency radio buttons, the integration view's mask/transparency/autoprocess widgets and calibration label, the configuration factor field) are now declarative bindings; the binder gained number-field and radio-pair binding kinds
+
 - the automatic (smooth Bruckner) background settings — smoothing width, iterations, polynomial order and the fitted x-range — are now canonical evented state in `PatternParams` with the pattern model pushing them into the pattern computation, instead of living in spinboxes and inside xypattern's internals; project save/load no longer reaches into those internals, and the range restored from a project is no longer clamped against whichever pattern happens to be loaded at that moment
 
 - `Configuration.copy()` now copies every setting generically instead of a hand-picked subset (it silently dropped the mask usage, integration unit, cake settings and auto-integrate flags)

--- a/dioptas/controller/ConfigurationController.py
+++ b/dioptas/controller/ConfigurationController.py
@@ -7,6 +7,8 @@ from ..widgets.UtilityWidgets import save_file_dialog
 from ..widgets.ConfigurationWidget import ConfigurationWidget
 from ..model.DioptasModel import DioptasModel
 
+from .binding import Binder
+
 
 class ConfigurationController:
     """
@@ -21,10 +23,13 @@ class ConfigurationController:
         self.widget = configuration_widget
         self.model = dioptas_model
         self.controllers = controllers
+        self.binder = Binder(field_events=self.model.configuration_params_changed)
 
         self.update_configuration_widget()
 
         self.create_signals()
+        self.binder.connect_refresh(self.model.configuration_selected)
+        self.binder.refresh()
 
     def create_signals(self):
         self.widget.add_configuration_btn.clicked.connect(self.model.add_configuration)
@@ -34,7 +39,6 @@ class ConfigurationController:
 
         self.model.configuration_added.connect(self.update_configuration_widget)
         self.model.configuration_removed.connect(self.update_configuration_widget)
-        self.model.configuration_selected.connect(self.configuration_selected)
 
         self.widget.next_file_btn.clicked.connect(self.load_next_file)
         self.widget.previous_file_btn.clicked.connect(self.load_previous_file)
@@ -42,7 +46,12 @@ class ConfigurationController:
         self.widget.next_folder_btn.clicked.connect(self.load_next_folder)
         self.widget.previous_folder_btn.clicked.connect(self.load_previous_folder)
 
-        self.widget.factor_txt.editingFinished.connect(self.factor_txt_changed)
+        self.binder.bind_number_field(
+            self.widget.factor_txt,
+            lambda: self.model.img_model,
+            "factor",
+            event_field="img.factor",
+        )
 
         self.widget.combine_patterns_btn.clicked.connect(self.combine_patterns_btn_clicked)
         self.widget.saved_combined_patterns_btn.clicked.connect(self.save_combined_patterns_btn_clicked)
@@ -53,9 +62,6 @@ class ConfigurationController:
             configurations=self.model.configurations,
             cur_ind=self.model.configuration_ind
         )
-
-    def configuration_selected(self):
-        self.widget.factor_txt.setText(str(self.model.img_model.factor))
 
     def combine_patterns_btn_clicked(self):
         self.model.combine_patterns = self.widget.combine_patterns_btn.isChecked()
@@ -74,9 +80,6 @@ class ConfigurationController:
 
     def combine_cakes_btn_clicked(self):
         self.model.combine_cakes = self.widget.combine_cakes_btn.isChecked()
-
-    def factor_txt_changed(self):
-        self.model.img_model.factor = float(str(self.widget.factor_txt.text()))
 
     def load_next_file(self):
         pos = int(str(self.widget.file_iterator_pos_txt.text()))

--- a/dioptas/controller/MaskController.py
+++ b/dioptas/controller/MaskController.py
@@ -14,6 +14,8 @@ from ..widgets.MaskPluginWidget import MaskPluginSettingsDialog
 from ..widgets.MaskWidget import MaskWidget
 from ..model.DioptasModel import DioptasModel
 
+from .binding import Binder
+
 
 class MaskController:
     DEFAULT_MASK_FILTER = 'Mask (*.mask)'
@@ -28,6 +30,7 @@ class MaskController:
         """
         self.widget = widget
         self.model = dioptas_model
+        self.binder = Binder(field_events=self.model.configuration_params_changed)
 
         self.state = None
         self.clicks = 0
@@ -61,8 +64,13 @@ class MaskController:
         self.widget.add_mask_btn.clicked.connect(self.add_mask_btn_click)
         self.widget.mask_rb.clicked.connect(self.mask_rb_click)
         self.widget.unmask_rb.clicked.connect(self.unmask_rb_click)
-        self.widget.fill_rb.clicked.connect(self.fill_rb_click)
-        self.widget.transparent_rb.clicked.connect(self.transparent_rb_click)
+        self.binder.bind_radio_pair(
+            self.widget.transparent_rb,
+            self.widget.fill_rb,
+            lambda: self.model.current_configuration,
+            "transparent_mask",
+            on_changed=self._apply_mask_transparency,
+        )
 
         self.widget.point_size_sb.valueChanged.connect(self.set_point_size)
         self.widget.img_widget.mouse_moved.connect(self.show_img_mouse_position)
@@ -572,15 +580,11 @@ class MaskController:
         self.widget.img_widget.mask_preview_fill_color = QtGui.QColor(0, 255, 0, 150)
         self.update_shape_preview_fill_color()
 
-    def fill_rb_click(self):
-        self.model.transparent_mask = False
-        self.widget.img_widget.set_mask_color([255, 0, 0, 255])
-        self.plot_mask()
-
-    #
-    def transparent_rb_click(self):
-        self.model.transparent_mask = True
-        self.widget.img_widget.set_mask_color([255, 0, 0, 100])
+    def _apply_mask_transparency(self, transparent):
+        """Display side effect following the transparent_mask setting."""
+        self.widget.img_widget.set_mask_color(
+            [255, 0, 0, 100] if transparent else [255, 0, 0, 255]
+        )
         self.plot_mask()
 
     def show_img_mouse_position(self, x, y):
@@ -596,15 +600,7 @@ class MaskController:
 
     def update_gui(self):
         self.plot_image()
-
-        # transparency
-        if self.model.transparent_mask:
-            self.widget.transparent_rb.setChecked(True)
-            self.transparent_rb_click()
-        else:
-            self.widget.fill_rb.setChecked(True)
-            self.fill_rb_click()
-
+        self.binder.refresh()  # transparency radios + their display effect
         self._update_plugin_checkboxes()
         self.plot_mask()
 

--- a/dioptas/controller/binding.py
+++ b/dioptas/controller/binding.py
@@ -101,6 +101,66 @@ class Binder:
             field=event_field or field,
         )
 
+    def bind_number_field(
+        self,
+        line_edit: Any,
+        owner: Callable[[], Any],
+        field: str,
+        dtype: Callable[[Any], Any] = float,
+        fmt: Callable[[Any], str] = str,
+        event_field: str | None = None,
+    ) -> None:
+        """Two-way binding for a QLineEdit-like numeric field.
+
+        The widget writes on editingFinished; invalid input is ignored and
+        the field re-renders from the model on the next refresh."""
+
+        def apply() -> None:
+            try:
+                value = dtype(line_edit.text())
+            except (TypeError, ValueError):
+                return
+            setattr(owner(), field, value)
+
+        line_edit.editingFinished.connect(apply)
+        self.add_render(
+            lambda: line_edit.setText(fmt(getattr(owner(), field))),
+            line_edit,
+            field=event_field or field,
+        )
+
+    def bind_radio_pair(
+        self,
+        true_btn: Any,
+        false_btn: Any,
+        owner: Callable[[], Any],
+        field: str,
+        event_field: str | None = None,
+        on_changed: Callable[[bool], None] | None = None,
+    ) -> None:
+        """Two-way binding for two mutually exclusive buttons representing a
+        boolean field.
+
+        *on_changed* runs after every render with the current value — use it
+        for display side effects that follow the setting."""
+        true_btn.clicked.connect(lambda: setattr(owner(), field, True))
+        false_btn.clicked.connect(lambda: setattr(owner(), field, False))
+
+        def render() -> None:
+            value = bool(getattr(owner(), field))
+            # auto-exclusive buttons ignore setChecked(False), so unchecking
+            # is done with exclusivity temporarily disabled — this must not
+            # depend on the two buttons sharing a parent
+            for button, state in ((true_btn, value), (false_btn, not value)):
+                exclusive = button.autoExclusive()
+                button.setAutoExclusive(False)
+                button.setChecked(state)
+                button.setAutoExclusive(exclusive)
+            if on_changed is not None:
+                on_changed(value)
+
+        self.add_render(render, true_btn, false_btn, field=event_field or field)
+
     def bind_spinbox(
         self,
         spinbox: Any,

--- a/dioptas/controller/integration/ImageController.py
+++ b/dioptas/controller/integration/ImageController.py
@@ -17,6 +17,8 @@ from ...model.util.HelperModule import get_partial_index, get_partial_value
 
 from .EpicsController import EpicsController
 
+from ..binding import Binder
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +35,7 @@ class ImageController:
         """
         self.widget = widget
         self.model = dioptas_model
+        self.binder = Binder(field_events=self.model.configuration_params_changed)
 
         self.epics_controller = EpicsController(self.widget, self.model)
 
@@ -48,6 +51,25 @@ class ImageController:
 
         self.create_signals()
         self.create_mouse_behavior()
+
+        self.binder.add_render(
+            lambda: self.widget.img_mask_btn.setChecked(bool(self.model.use_mask)),
+            self.widget.img_mask_btn,
+            field="use_mask",
+        )
+        self.binder.add_render(
+            lambda: self.widget.autoprocess_cb.setChecked(
+                bool(self.model.img_model.autoprocess)
+            ),
+            self.widget.autoprocess_cb,
+            field="img.autoprocess",
+        )
+        self.binder.add_render(
+            lambda: self.widget.calibration_lbl.setText(
+                self.model.calibration_model.calibration_name
+            )
+        )
+        self.binder.refresh()
 
     def plot_img(self, auto_scale=None):
         """
@@ -122,16 +144,11 @@ class ImageController:
         else:
             self.widget.img_widget.deactivate_mask()
 
-    def update_mask_transparency(self):
-        """
-        Changes the colormap of the mask according to the transparency option selection in the GUI. Resulting Mask will
-        be either transparent or solid.
-        """
-        self.model.transparent_mask = self.widget.mask_transparent_cb.isChecked()
-        if self.model.transparent_mask:
-            self.widget.img_widget.set_mask_color([255, 0, 0, 100])
-        else:
-            self.widget.img_widget.set_mask_color([255, 0, 0, 255])
+    def _apply_mask_transparency(self, transparent):
+        """Display side effect following the transparent_mask setting."""
+        self.widget.img_widget.set_mask_color(
+            [255, 0, 0, 100] if transparent else [255, 0, 0, 255]
+        )
 
     def create_signals(self):
         self.model.configuration_selected.connect(self.update_gui_from_configuration)
@@ -165,7 +182,15 @@ class ImageController:
         # Image widget image specific controls
         self.widget.img_roi_btn.clicked.connect(self.click_roi_btn)
         self.widget.img_mask_btn.clicked.connect(self.change_mask_mode)
-        self.widget.mask_transparent_cb.clicked.connect(self.update_mask_transparency)
+        self.binder.bind_checkbox(
+            self.widget.mask_transparent_cb,
+            lambda: self.model.current_configuration,
+            "transparent_mask",
+        )
+        self.binder.add_render(
+            lambda: self._apply_mask_transparency(self.model.transparent_mask),
+            field="transparent_mask",
+        )
 
         ###
         # Image Widget cake specific controls
@@ -1049,10 +1074,7 @@ class ImageController:
                             out_file.write("{:6.2f}".format(azi) + row_str + '\n')
 
     def update_gui_from_configuration(self):
-        self.widget.img_mask_btn.setChecked(int(self.model.use_mask))
-        self.widget.mask_transparent_cb.setChecked(bool(self.model.transparent_mask))
-        self.widget.autoprocess_cb.setChecked(bool(self.model.img_model.autoprocess))
-        self.widget.calibration_lbl.setText(self.model.calibration_model.calibration_name)
+        self.binder.refresh()
 
         self.update_img_control_widget()
         self.update_mask_mode()

--- a/dioptas/tests/controller_tests/test_Binding.py
+++ b/dioptas/tests/controller_tests/test_Binding.py
@@ -207,3 +207,45 @@ def test_field_events_render_individual_bindings(qapp, settings):
 
     field_events.emit("points", 999, 360)
     assert spinbox.value() == 999
+
+
+def test_number_field_binding(qapp, binder, settings):
+    field = QtWidgets.QLineEdit()
+    binder.bind_number_field(field, lambda: settings, "points", dtype=float)
+
+    field.setText("2.5")
+    field.editingFinished.emit()
+    assert settings.points == 2.5
+
+    settings.points = 7.0
+    binder.refresh()
+    assert field.text() == "7.0"
+
+
+def test_number_field_binding_ignores_invalid_input(qapp, binder, settings):
+    field = QtWidgets.QLineEdit()
+    binder.bind_number_field(field, lambda: settings, "points", dtype=float)
+
+    settings.points = 5.0
+    field.setText("not a number")
+    field.editingFinished.emit()
+    assert settings.points == 5.0  # unchanged
+
+
+def test_radio_pair_binding(qapp, binder, settings):
+    true_btn = QtWidgets.QRadioButton()
+    false_btn = QtWidgets.QRadioButton()
+    seen = []
+    binder.bind_radio_pair(
+        true_btn, false_btn, lambda: settings, "flag", on_changed=seen.append
+    )
+
+    true_btn.click()
+    assert settings.flag is True
+    false_btn.click()
+    assert settings.flag is False
+
+    settings.flag = True
+    binder.refresh()
+    assert true_btn.isChecked() and not false_btn.isChecked()
+    assert seen[-1] is True  # display side effect follows the setting


### PR DESCRIPTION
Task 5 from the post-refactor list: the last hand-written model→widget pushes become bindings.

Two new binding kinds:
- **`bind_number_field`** — two-way binding for numeric `QLineEdit`s, ignoring invalid input instead of raising (the configuration factor field previously called `float(text)` unguarded).
- **`bind_radio_pair`** — a boolean shown as two exclusive buttons, with an `on_changed` hook for the display side effect that follows the setting.

Migrated:
- **MaskController**: the transparency radios. Its `fill_rb_click`/`transparent_rb_click` handlers are gone — `update_gui` used to *call* them to re-push widget state, which redundantly rewrote the model on every refresh.
- **ImageController**: mask-transparency checkbox, use-mask button, autoprocess checkbox and the calibration label; `update_gui_from_configuration`'s four manual pushes collapse to `binder.refresh()`.
- **ConfigurationController**: the factor field (its `configuration_selected` push and `factor_txt_changed` handler both disappear).

One Qt subtlety worth recording: `setChecked(False)` is **ignored on an auto-exclusive radio button**, so the pair render temporarily disables exclusivity while unchecking. The old code only worked because those two radios happen to share a parent — a unit test with standalone buttons caught it.

Full suite: 1054 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)