### PR TITLE
Change-driven session backup; fix calibration rename when adding a configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,13 @@
 
 ## Bugfixes
 
+- adding a configuration renamed the calibration of both the new and the original configuration to "transfer" (the name of the temporary file the calibration is transferred through), which was then shown in the calibration label and saved into project files
+
 - setting an integer intensity factor (e.g. from a script) silently wrapped uint16 image pixel values around; the factor is now coerced to float
 
 ## Internal
+
+- the periodic session backup now only writes when something actually changed, instead of rewriting the whole project (including image data) every ten minutes in an idle session; closing Dioptas still saves unconditionally
 
 - the remaining hand-written `update_gui` pushes (mask transparency radio buttons, the integration view's mask/transparency/autoprocess widgets and calibration label, the configuration factor field) are now declarative bindings; the binder gained number-field and radio-pair binding kinds
 

--- a/dioptas/controller/MainController.py
+++ b/dioptas/controller/MainController.py
@@ -311,10 +311,35 @@ class MainController:
                 self.load_directories()
 
     def setup_backup_timer(self):
+        """Periodically backs up the session, but only when something changed.
+
+        The backup writes the whole project (including image data), so the
+        write frequency stays bounded by the timer; the dirty flag only
+        removes the pointless writes of an idle session."""
+        self._backup_dirty = False
+        for signal in (
+            self.model.configuration_params_changed,
+            self.model.img_changed,
+            self.model.pattern_changed,
+            self.model.configuration_added,
+            self.model.configuration_removed,
+        ):
+            signal.connect(self._mark_backup_dirty)
+        self.model.view.events.connect(self._mark_backup_dirty)
+
         self.backup_timer = QtCore.QTimer(self.widget)
-        self.backup_timer.timeout.connect(self.save_default_settings)
+        self.backup_timer.timeout.connect(self.save_backup_if_changed)
         self.backup_timer.setInterval(600000)  # every 10 minutes
         self.backup_timer.start()
+
+    def _mark_backup_dirty(self, *_args):
+        self._backup_dirty = True
+
+    def save_backup_if_changed(self):
+        if not self._backup_dirty:
+            return
+        self.save_default_settings()
+        self._backup_dirty = False
 
     def save_directories(self):
         """

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -128,16 +128,25 @@ class DioptasModel:
         logger.info("Adding new configuration")
         self.configurations.append(Configuration(self.working_directories))
 
-        if self.current_configuration.calibration_model.is_calibrated:
+        source_calibration = self.current_configuration.calibration_model
+        if source_calibration.is_calibrated:
             dioptas_config_folder = os.path.join(os.path.expanduser("~"), ".Dioptas")
             if not os.path.isdir(dioptas_config_folder):
                 os.mkdir(dioptas_config_folder)
-            self.current_configuration.calibration_model.save(
-                os.path.join(dioptas_config_folder, "transfer.poni")
-            )
-            self.configurations[-1].calibration_model.load(
-                os.path.join(dioptas_config_folder, "transfer.poni")
-            )
+            # the calibration is transferred through a temporary poni file;
+            # save()/load() overwrite the calibration name and filename, so
+            # they are restored afterwards for both configurations
+            calibration_name = source_calibration.calibration_name
+            calibration_filename = source_calibration.filename
+            transfer_path = os.path.join(dioptas_config_folder, "transfer.poni")
+            source_calibration.save(transfer_path)
+            self.configurations[-1].calibration_model.load(transfer_path)
+            for calibration_model in (
+                source_calibration,
+                self.configurations[-1].calibration_model,
+            ):
+                calibration_model.calibration_name = calibration_name
+                calibration_model.filename = calibration_filename
 
         self.configurations[-1].img_model._img_data = (
             self.current_configuration.img_model.img_data

--- a/dioptas/tests/controller_tests/test_MainController.py
+++ b/dioptas/tests/controller_tests/test_MainController.py
@@ -139,3 +139,25 @@ def test_title_is_shown_correctly(main_controller: MainController):
     assert title.startswith("image_001.tif, calibration: CeO2_Pilatus1M | Dioptas")
     assert title.endswith("C. Prescher")
 
+
+
+def test_backup_skips_when_nothing_changed(main_controller, tmp_path):
+    """The periodic backup only writes when something actually changed."""
+    from unittest.mock import MagicMock
+
+    main_controller.setup_backup_timer()
+    main_controller.save_default_settings = MagicMock()
+
+    # freshly set up: nothing has changed yet
+    main_controller._backup_dirty = False
+    main_controller.save_backup_if_changed()
+    main_controller.save_default_settings.assert_not_called()
+
+    # any settings change marks the session dirty
+    main_controller.model.current_configuration.params.use_mask = True
+    main_controller.save_backup_if_changed()
+    main_controller.save_default_settings.assert_called_once()
+
+    # and the flag clears again
+    main_controller.save_backup_if_changed()
+    main_controller.save_default_settings.assert_called_once()

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -940,3 +940,24 @@ def test_view_params_round_trip_all_fields(dioptas_model, tmp_path):
     assert dioptas_model.view.view_mode == "alternative"
     assert dioptas_model.view.img_docked is False
     assert dioptas_model.view.waterfall_separation == 42.0
+
+
+def test_add_configuration_preserves_calibration_name(dioptas_model):
+    """Transferring the calibration to a new configuration must not rename it.
+
+    The transfer goes through a temporary poni file, whose save/load
+    overwrote the calibration name of both configurations with "transfer"."""
+    dioptas_model.calibration_model.load(
+        os.path.join(data_path, "CeO2_Pilatus1M.poni")
+    )
+    dioptas_model.img_model.load(os.path.join(data_path, "CeO2_Pilatus1M.tif"))
+    assert dioptas_model.calibration_model.calibration_name == "CeO2_Pilatus1M"
+
+    dioptas_model.add_configuration()
+
+    assert dioptas_model.calibration_model.is_calibrated
+    assert dioptas_model.calibration_model.calibration_name == "CeO2_Pilatus1M"
+    assert (
+        dioptas_model.configurations[0].calibration_model.calibration_name
+        == "CeO2_Pilatus1M"
+    )


### PR DESCRIPTION
Task 6 from the post-refactor list, plus a real bug found while reading that path.

## Backup only when something changed

The 10-minute timer rewrote the whole project — image data included — unconditionally. It now keeps a dirty flag fed by `configuration_params_changed` (the store-level settings surface), the img/pattern signals, configuration add/remove, and the view events; `save_backup_if_changed()` skips the write when nothing changed.

The interval is deliberately **unchanged**: a full-project save is expensive, so the worst-case write frequency stays exactly what it was — only the pointless writes of an idle session disappear (meaningful on a beamline machine sitting between measurements with a large project open). Closing Dioptas still saves unconditionally.

## Bug: adding a configuration renamed the calibration to "transfer"

The calibration is copied to a new configuration by writing `~/.Dioptas/transfer.poni` and loading it back — and `CalibrationModel.save()`/`load()` set `calibration_name`/`filename` as a side effect. So after "add configuration", **both** configurations reported their calibration as "transfer" instead of e.g. `CeO2_Pilatus1M` — visible in the calibration label and written into saved projects. Verified empirically before and after; the names are now restored after the transfer.

I considered replacing the file round-trip with an in-memory geometry copy and **rejected it for now**: `save()` writes the *cake* geometry through `poni_flipud` and `load()` flips back (the two cancel), and the destination's detector `max_shape` differs, so it is not a behaviour-preserving swap — not something to change casually in a calibration path.

Full suite: 1056 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)