### PR TITLE
Params documents drive settings restore (and a tuple round-trip fix)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,15 @@
 
 - the corrections panel layout was off after the parameter form rework: input fields stretched across the whole panel, tabs with only a few parameters spread their rows over the full height, and the plot buttons sat at the far right edge — fields now keep a compact width, rows are packed to the top, formula inputs line up with the parameter labels, and the plot buttons sit next to (or below) the values they belong to
 
+- settings stored as tuples (the mask region of interest, phase colors) came back as lists after a project round-trip, because JSON has no tuple type
+
 - adding a configuration renamed the calibration of both the new and the original configuration to "transfer" (the name of the temporary file the calibration is transferred through), which was then shown in the calibration label and saved into project files
 
 - setting an integer intensity factor (e.g. from a script) silently wrapped uint16 image pixel values around; the factor is now coerced to float
 
 ## Internal
+
+- restoring settings from a project file no longer needs per-field code: the generic params documents are applied wholesale on top of the legacy restore, so any settings field added in future round-trips automatically
 
 - the periodic session backup now only writes when something actually changed, instead of rewriting the whole project (including image data) every ten minutes in an idle session; closing Dioptas still saves unconditionally
 

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -18,6 +18,7 @@ from .state import (
     ConfigurationParams,
     ImgParams,
     MaskParams,
+    PatternParams,
     save_params,
     load_params,
     Derived,
@@ -825,6 +826,12 @@ class Configuration:
         ):
             self._load_from_hdf5(hdf5_group)
 
+    @staticmethod
+    def _apply_saved_params(target, saved, exclude=None) -> None:
+        """Applies a params document loaded from a project file, if present."""
+        if saved is not None:
+            apply_params(target, saved, exclude=exclude)
+
     def _load_from_hdf5(self, hdf5_group: h5py.Group) -> None:
         f = hdf5_group
 
@@ -1142,37 +1149,36 @@ class Configuration:
                 val = val.decode("utf-8")
             self.integrated_patterns_file_formats.append(str(val))
 
-        # apply params saved by the generic state layer (project files written
-        # since its introduction). Fields that also exist in the legacy layout
-        # were already restored above with their loading side effects, so only
-        # the fields the legacy layout never persisted are taken from here.
-        saved_params = load_params(f, ConfigurationParams)
-        if saved_params is not None:
-            self.params.oned_azimuth_range = saved_params.oned_azimuth_range
-            self.params.trim_trailing_zeros = saved_params.trim_trailing_zeros
-
-        saved_img_params = load_params(f.get("image_model"), ImgParams)
-        if saved_img_params is not None:
-            self.img_model.params.file_iteration_mode = (
-                saved_img_params.file_iteration_mode
-            )
-
-        saved_mask_params = load_params(f.get("mask"), MaskParams)
-        if saved_mask_params is not None:
-            self.mask_model.params.mode = saved_mask_params.mode
-
-        # calibration workflow settings absent from the legacy layout;
-        # use_dioptrin / dioptrin_num_workers are machine-specific and are
-        # deliberately NOT restored from project files
-        saved_calibration_params = load_params(
-            f.get("calibration_model"), CalibrationParams
+        # Apply the generic params documents on top of the legacy restore
+        # above. Both are written from the same in-memory state by save(),
+        # so for every field the legacy layout knows about this is a no-op
+        # (equal values emit nothing) — and every field it does NOT know
+        # about is restored automatically, with no per-field bookkeeping
+        # here. The exclusions below are the fields whose legacy restore is
+        # not a plain copy and must win.
+        self._apply_saved_params(
+            self.params,
+            load_params(f, ConfigurationParams),
+            # the legacy restore drops working directories that no longer
+            # exist on this machine; that validation must not be undone
+            exclude={"working_directories"},
         )
-        if saved_calibration_params is not None:
-            calibration_params = self.calibration_model.params
-            calibration_params.start_values = saved_calibration_params.start_values
-            calibration_params.fit_wavelength = saved_calibration_params.fit_wavelength
-            calibration_params.fixed_values = saved_calibration_params.fixed_values
-            calibration_params.use_mask = saved_calibration_params.use_mask
+        self._apply_saved_params(
+            self.img_model.params, load_params(f.get("image_model"), ImgParams)
+        )
+        self._apply_saved_params(
+            self.mask_model.params, load_params(f.get("mask"), MaskParams)
+        )
+        self._apply_saved_params(
+            self.pattern_model.params, load_params(f.get("pattern"), PatternParams)
+        )
+        self._apply_saved_params(
+            self.calibration_model.params,
+            load_params(f.get("calibration_model"), CalibrationParams),
+            # machine-specific: the effective defaults are computed per
+            # machine at construction and must not travel in project files
+            exclude={"use_dioptrin", "dioptrin_num_workers"},
+        )
 
         if self.calibration_model.is_calibrated:
             self.integrate_image_1d()

--- a/dioptas/model/state/hdf5.py
+++ b/dioptas/model/state/hdf5.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import types
 import typing
 from typing import Any, TypeVar
 
@@ -69,7 +70,12 @@ logger = logging.getLogger(__name__)
 #: version of the params-group JSON encoding (see module docstring)
 SCHEMA_VERSION = 1
 
-#: version of the overall .dio project file layout (see module docstring)
+#: version of the overall .dio project file layout (see module docstring).
+#: Stays at 1 while writers still emit the legacy field-by-field attributes
+#: alongside the params documents: the file remains readable by Dioptas
+#: versions that predate the params layer, so there is nothing for a reader
+#: to branch on. Bump to 2 together with dropping the legacy writer — that
+#: is the change older versions must not silently misread.
 PROJECT_FORMAT_VERSION = 1
 
 T = TypeVar("T")
@@ -88,6 +94,18 @@ def _json_default(obj: object) -> int | float | list:
 def params_to_dict(params: Any) -> dict:
     """Converts a params dataclass (including nested dataclasses) to a dict."""
     return dataclasses.asdict(params)
+
+
+def _wants_tuple(field_type: Any) -> bool:
+    """Whether a dataclass field is declared as a tuple (JSON has no tuples)."""
+    if field_type is tuple:
+        return True
+    origin = typing.get_origin(field_type)
+    if origin is tuple:
+        return True
+    if origin in (typing.Union, types.UnionType):
+        return any(_wants_tuple(arg) for arg in typing.get_args(field_type))
+    return False
 
 
 def params_from_dict(cls: type[T], data: dict) -> T:
@@ -112,6 +130,10 @@ def params_from_dict(cls: type[T], data: dict) -> T:
             and isinstance(value, dict)
         ):
             value = params_from_dict(field_type, value)
+        elif isinstance(value, list) and _wants_tuple(field_type):
+            # JSON round-trips tuples as lists; restore the declared type so
+            # a loaded value compares equal to a freshly set one
+            value = tuple(value)
         kwargs[f.name] = value
     return cls(**kwargs)
 

--- a/dioptas/model/state/params.py
+++ b/dioptas/model/state/params.py
@@ -40,16 +40,24 @@ __all__ = [
 ]
 
 
-def apply_params(target: Any, source: Any, fields: set[str] | None = None) -> None:
+def apply_params(
+    target: Any,
+    source: Any,
+    fields: set[str] | None = None,
+    exclude: set[str] | None = None,
+) -> None:
     """Copies field values from *source* onto the existing *target* instance.
 
     The target keeps its identity, so event subscriptions on it stay valid,
     and every differing field emits its change event (and therefore runs
     its reactions). Mutable values are deep-copied so the two instances do
-    not share state. Pass *fields* to restrict the copy to a subset.
+    not share state. Pass *fields* to restrict the copy to a subset, or
+    *exclude* to skip individual fields.
     """
     for f in dataclasses.fields(target):
         if fields is not None and f.name not in fields:
+            continue
+        if exclude is not None and f.name in exclude:
             continue
         value = getattr(source, f.name)
         if isinstance(value, (dict, list, set)):

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -961,3 +961,69 @@ def test_add_configuration_preserves_calibration_name(dioptas_model):
         dioptas_model.configurations[0].calibration_model.calibration_name
         == "CeO2_Pilatus1M"
     )
+
+
+def test_params_restore_is_not_hand_listed(dioptas_model, tmp_path):
+    """Settings restore comes from the params documents wholesale.
+
+    Every settings field round-trips without per-field code in the loader,
+    including fields the legacy layout never writes."""
+    from dioptas.model.state import params_to_dict
+
+    configuration = dioptas_model.current_configuration
+    configuration.params.trim_trailing_zeros = False
+    configuration.params.oned_azimuth_range = [-45.0, 45.0]
+    configuration.params.cake_azimuth_range = [-100.0, 100.0]
+    configuration.img_model.params.file_iteration_mode = "time"
+    configuration.mask_model.params.mode = False
+    configuration.pattern_model.params.file_iteration_mode = "time"
+    configuration.calibration_model.params.fit_wavelength = True
+    configuration.calibration_model.params.fixed_values = {"rot1": 0.25}
+
+    expected = {
+        "configuration": params_to_dict(configuration.params),
+        "img": params_to_dict(configuration.img_model.params),
+        "mask": params_to_dict(configuration.mask_model.params),
+        # "unit" is excluded: it tracks the last integration, and loading
+        # ends with one, so it is not expected to match the pre-save value
+        "pattern": {
+            k: v
+            for k, v in params_to_dict(configuration.pattern_model.params).items()
+            if k != "unit"
+        },
+    }
+
+    filename = os.path.join(tmp_path, "wholesale.dio")
+    dioptas_model.save(filename)
+    dioptas_model.reset()
+    dioptas_model.load(filename)
+
+    restored = dioptas_model.current_configuration
+    assert params_to_dict(restored.params) == expected["configuration"]
+    assert params_to_dict(restored.img_model.params) == expected["img"]
+    assert params_to_dict(restored.mask_model.params) == expected["mask"]
+    assert {
+        k: v
+        for k, v in params_to_dict(restored.pattern_model.params).items()
+        if k != "unit"
+    } == expected["pattern"]
+    assert restored.calibration_model.params.fit_wavelength is True
+    assert restored.calibration_model.params.fixed_values == {"rot1": 0.25}
+
+
+def test_missing_working_directories_are_not_restored(dioptas_model, tmp_path):
+    """The legacy restore drops directories that no longer exist; the
+    wholesale params apply must not undo that validation."""
+    gone = os.path.join(tmp_path, "no_longer_there")
+    dioptas_model.current_configuration.params.working_directories = {
+        "image": gone,
+        "pattern": str(tmp_path),
+    }
+
+    filename = os.path.join(tmp_path, "dirs.dio")
+    dioptas_model.save(filename)
+    dioptas_model.load(filename)
+
+    restored = dioptas_model.current_configuration.working_directories
+    assert restored["image"] == ""  # dropped: does not exist
+    assert restored["pattern"] == str(tmp_path)  # kept: exists

--- a/dioptas/tests/unit_tests/test_state.py
+++ b/dioptas/tests/unit_tests/test_state.py
@@ -388,3 +388,15 @@ def test_phase_item_params_events():
     params.events.visible.connect(lambda new, old: got.append(new))
     params.visible = False
     assert got == [False]
+
+
+def test_tuple_fields_survive_the_json_round_trip():
+    """JSON has no tuple type; declared tuple fields must not become lists."""
+    params = MaskParams(roi=(10, 20, 30, 40))
+    restored = params_from_dict(MaskParams, params_to_dict(params))
+    assert restored.roi == (10, 20, 30, 40)
+    assert isinstance(restored.roi, tuple)
+
+    item = PhaseItemParams(color=(1, 2, 3))
+    restored_item = params_from_dict(PhaseItemParams, params_to_dict(item))
+    assert isinstance(restored_item.color, tuple)


### PR DESCRIPTION
The substance of the ".dio format v2" item: **params documents become the authoritative restore path for settings**, so the loader no longer needs per-field code.

## Wholesale restore

The hand-listed "gap field" lines are replaced by applying each params document on top of the legacy restore. This is safe because `save()` writes the legacy attributes *and* the params documents from the same in-memory state — they can never disagree. So for every field the legacy layout knows about the apply is a **no-op** (equal values emit nothing), and every field it doesn't know about is restored automatically. **Settings added in future round-trip with no loader changes.**

Two exclusions, both where the legacy restore is deliberately not a plain copy:
- `working_directories` — the legacy path drops directories that no longer exist on this machine; that validation must win (covered by a test).
- `use_dioptrin` / `dioptrin_num_workers` — machine-specific, never carried in project files.

## Bug found: tuples came back as lists

JSON has no tuple type, so tuple-typed settings (`MaskParams.roi`, `PhaseItemParams.color`) round-tripped as lists — caught by `test_with_roi` once params started driving the restore. Fixed in the codec rather than special-cased: `params_from_dict` now restores the declared type, so a loaded value compares equal to a freshly set one.

## On the version number

**`PROJECT_FORMAT_VERSION` deliberately stays at 1.** Writers still emit the legacy attributes, so these files remain readable by Dioptas versions predating the params layer, and a reader has nothing to branch on — bumping now would signal a compatibility break that hasn't happened. The bump belongs with *dropping the legacy writer*, which is the change older versions must not silently misread. That reasoning is now recorded at the constant so the next person doesn't have to re-derive it.

Full suite: 1059 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)