### PR TITLE
Close the batch file in is_proc when reading it raises

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Bugfixes
 
+- checking whether a batch file contains processed data left the file open when reading it raised, which then blocked every later write to that file (same failure mode as the autosave handle leak)
+
 - saving the session (autosave or on close) crashed with "Object of type bool is not JSON serializable" after restoring a previous session, because loading assigned numpy booleans from the project file into the settings; on top of that, the failed save leaked its open file handle, so every following autosave failed with "unable to truncate a file which is already open" — numpy scalars now serialize, and save/load always close the project file even when they fail partway
 
 - the corrections panel layout was off after the parameter form rework: input fields stretched across the whole panel, tabs with only a few parameters spread their rows over the full height, and the plot buttons sat at the far right edge — fields now keep a compact width, rows are packed to the top, formula inputs line up with the parameter labels, and the plot buttons sit next to (or below) the values they belong to

--- a/dioptas/controller/integration/BatchController.py
+++ b/dioptas/controller/integration/BatchController.py
@@ -821,12 +821,14 @@ class BatchController:
         Check if file contains processed data
         """
         if os.path.splitext(filename)[1] == ".nxs":
-            data_file = h5py.File(filename, "r")
-            if "processed" in data_file:
-                return True
-            # ToDo Check for old format. To be removed
-            if "data" in data_file:
-                return True
+            # the handle must be closed on every path: a leaked reader blocks
+            # later writes to the same file
+            with h5py.File(filename, "r") as data_file:
+                if "processed" in data_file:
+                    return True
+                # ToDo Check for old format. To be removed
+                if "data" in data_file:
+                    return True
         return False
 
     def load_raw_data(self, filenames):

--- a/dioptas/tests/controller_tests/test_BatchController_part1.py
+++ b/dioptas/tests/controller_tests/test_BatchController_part1.py
@@ -45,6 +45,27 @@ def test_is_proc(batch_controller, load_proc_data):
     assert batch_controller.is_proc(filename)
 
 
+def test_is_proc_closes_the_file_even_when_reading_raises(
+    batch_controller, tmp_path, monkeypatch
+):
+    """is_proc must close the file on every path.
+
+    On a normal return CPython's refcounting closes it anyway, but when an
+    exception propagates the traceback keeps the frame — and with it a bare
+    handle — alive, and every later write to that file then fails."""
+    from unittest.mock import MagicMock
+
+    handle = MagicMock()
+    handle.__enter__.return_value = handle
+    handle.__contains__.side_effect = OSError("corrupt file")
+    monkeypatch.setattr("h5py.File", MagicMock(return_value=handle))
+
+    with pytest.raises(OSError):
+        batch_controller.is_proc(os.path.join(tmp_path, "corrupt.nxs"))
+
+    handle.__exit__.assert_called()
+
+
 def test_change_3d_view(batch_controller, batch_widget):
     batch_widget.activate_surface_view()
 


### PR DESCRIPTION
Follow-up to the autosave handle-leak fix (4d8280fb), which prompted a look for the same pattern elsewhere.

`BatchController.is_proc()` opened the `.nxs` file with a bare `h5py.File(...)` and never closed it.

**Scope, measured rather than assumed:** on a normal return this is *not* a leak — CPython's refcounting closes the handle as soon as the function returns, which I verified experimentally. The hazard is the **exception path**: if reading raises (a corrupt or truncated file makes the membership test throw), the propagating traceback keeps the frame alive, and with it the handle. Every later write to that file then fails with `unable to truncate a file which is already open` — exactly the failure mode just fixed in the autosave path.

The `with` block closes it on every path.

The regression test drives the exception path and asserts the context manager exits. I verified it **fails against the previous implementation and passes against the fix** — my first attempt at this test passed both ways (it exercised only the normal return, where refcounting hides the problem), which is what exposed that my original "this is a real leak" framing was too broad.

Full suite: 1063 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)