### PR TITLE
Store images in their native dtype, compressed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+- images are stored in their own dtype and compressed in project files, instead of being converted to 32-bit floats: a project holding a 2048² 16-bit image drops from about 17 MB to 4.5 MB, and reloading an image now returns exactly the data that was loaded (converting to float doubled the size of 16-bit detector data and lost precision above 16.7 million counts)
+
 - the mask is stored compressed in project files (gzip level 1): a saved mask shrinks about 190x (4.2 MB to 22 KB for a 2048² detector, 18 MB to 0.12 MB for a 4M one), which also makes the session autosave far cheaper; gzip is a built-in HDF5 filter, so older Dioptas versions still read these files
 
 - the mask undo/redo history stores bit-packed snapshots instead of full byte-per-pixel arrays, cutting its memory by 8x (about 900 MB to 113 MB for a 4M-pixel detector at the 50-step depth)

--- a/dioptas/model/Configuration.py
+++ b/dioptas/model/Configuration.py
@@ -54,6 +54,24 @@ def _json_numpy_default(obj: object) -> object:
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
+def _create_image_dataset(group: h5py.Group, name: str, data: np.ndarray):
+    """Stores image data in its native dtype, compressed.
+
+    The dtype used to be forced to float32, which doubled the size of the
+    common uint16 detector data, made the .dio round-trip change the dtype
+    (a freshly loaded TIFF is uint16, the same image reloaded from a project
+    was float32), and silently lost precision for integer counts above 2**24.
+
+    gzip level 1 with the shuffle filter: on real diffraction images shuffle
+    makes the result both smaller AND faster to write (byte-transposing gives
+    deflate longer runs), and level 4 buys ~3% more size for ~40% more time.
+    Both are built-in HDF5 filters, so any other HDF5 reader still opens it.
+    """
+    return group.create_dataset(
+        name, data=data, compression="gzip", compression_opts=1, shuffle=True
+    )
+
+
 class Configuration:
     """
     The configuration class contains a working combination of an ImgModel, PatternModel, MaskModel and CalibrationModel.
@@ -628,9 +646,7 @@ class Configuration:
         image_group.attrs["background_scaling"] = self.img_model.background_scaling
         if self.img_model.has_background():
             background_data = self.img_model.untransformed_background_data
-            image_group.create_dataset(
-                "background_data", background_data.shape, "f", background_data
-            )
+            _create_image_dataset(image_group, "background_data", background_data)
 
         image_group.attrs["series_max"] = self.img_model.series_max
         image_group.attrs["series_pos"] = self.img_model.series_pos
@@ -675,10 +691,7 @@ class Configuration:
         image_group.attrs["filename"] = self.img_model.filename
         current_raw_image = self.img_model.untransformed_raw_img_data
 
-        raw_image_data = image_group.create_dataset(
-            "raw_image_data", current_raw_image.shape, dtype="f"
-        )
-        raw_image_data[...] = current_raw_image
+        _create_image_dataset(image_group, "raw_image_data", current_raw_image)
 
         # image transformations
         transformations_group = image_group.create_group("image_transformations")

--- a/dioptas/tests/unit_tests/test_DioptasModel.py
+++ b/dioptas/tests/unit_tests/test_DioptasModel.py
@@ -1057,3 +1057,44 @@ def test_missing_working_directories_are_not_restored(dioptas_model, tmp_path):
     restored = dioptas_model.current_configuration.working_directories
     assert restored["image"] == ""  # dropped: does not exist
     assert restored["pattern"] == str(tmp_path)  # kept: exists
+
+
+def test_image_round_trip_preserves_dtype_and_values(dioptas_model, tmp_path):
+    """A project round-trip must return the image exactly as loaded.
+
+    Images used to be stored as float32 regardless of the detector dtype, so
+    reloading a uint16 image from a project gave float32 back — and integer
+    counts above 2**24 lost precision."""
+    dioptas_model.img_model.load(os.path.join(data_path, "image_001.tif"))
+    original = dioptas_model.img_model.raw_img_data.copy()
+    assert original.dtype == np.uint16  # guard: the fixture image is integer
+
+    filename = os.path.join(tmp_path, "image_round_trip.dio")
+    dioptas_model.save(filename)
+    dioptas_model.load(filename)
+
+    restored = dioptas_model.img_model.raw_img_data
+    assert restored.dtype == original.dtype
+    assert np.array_equal(restored, original)
+
+
+def test_image_and_background_are_stored_compressed(dioptas_model, tmp_path):
+    import h5py
+
+    dioptas_model.img_model.load(os.path.join(data_path, "image_001.tif"))
+    dioptas_model.img_model.background_data = np.zeros(
+        dioptas_model.img_model.raw_img_data.shape, dtype=np.uint16
+    )
+
+    filename = os.path.join(tmp_path, "compressed_image.dio")
+    dioptas_model.save(filename)
+
+    with h5py.File(filename, "r") as f:
+        image_group = f["configurations/0/image_model"]
+        for name in ("raw_image_data", "background_data"):
+            dataset = image_group[name]
+            assert dataset.compression == "gzip"
+            assert dataset.shuffle
+            stored = dataset.id.get_storage_size()
+            raw = dataset.size * dataset.dtype.itemsize
+            assert stored < raw


### PR DESCRIPTION
Follow-up to the mask storage work (#242), from benchmarking the other large dataset in a project file.

## The finding wasn't compression

`.dio` wrote **every image as float32** regardless of the detector dtype. Three costs:

1. **Doubles the common case** — uint16 detector data: 8.4 MB stored as 16.8 MB.
2. **Subtly lossy** — float32 represents integers exactly only below 2²⁴; accumulated counts above ~16.7M would silently drift. (The Pilatus test file peaks at 621k, so nothing in the suite was exposed.)
3. **Unfaithful round-trip** — verified: a freshly loaded TIFF is `uint16`, the same image reloaded from a project came back `float32`. Since the conversion happens only on save, it reads as an oversight rather than a deliberate normalisation — a normalisation would have been applied at load.

I checked the plausible defence (forcing float to avoid integer wraparound in the corrections math) and it doesn't hold: subtracting a background from a uint16 image already yields `float64` via numpy promotion (`min = -10.0` in the test), and freshly loaded TIFFs are uint16 in normal operation anyway.

## Result

Native dtype + gzip‑1 + shuffle, for both the image and the background image:

| project containing | before | after |
|---|---|---|
| 2048² uint16 image | ~17 MB | **4.55 MB** |
| Pilatus int32 image | 4.09 MB | **0.92 MB** |

Save cost: 61 ms and 17 ms respectively (from ~3 ms), against 12 MB less data written — on beamline network storage that very likely nets out faster.

Benchmarked on real detector data, not synthetic arrays. `shuffle` makes files **smaller and faster** simultaneously (118 ms/7.17 MB → 88 ms/5.49 MB on one image), since byte-transposing gives deflate longer runs. gzip‑4 buys ~3% size for ~40% more time. Both are built-in HDF5 filters, so other readers still open these files.

Tests assert the round-trip preserves dtype **and** values exactly, and that both datasets are genuinely stored compressed.

Full suite: 1095 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)