### PR TITLE
Fix the macOS wheels and make a skipped PyPI publish fail loudly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,18 +298,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+          # Apple silicon: built WITH OpenMP. Homebrew's libomp on this runner
+          # has a minimum target of macOS 14, and delocate refuses to bundle a
+          # library into a wheel tagged for an older macOS, so the wheel's
+          # target is raised to match. Apple silicon Macs all run 14 or newer
+          # in practice; older ones fall back to the sdist.
+          - os: macos-14
+            openmp: true
+            cibw_env_macos: MACOSX_DEPLOYMENT_TARGET=14.0
+          # Intel: built WITHOUT OpenMP on purpose. Installing libomp here
+          # would force this wheel's minimum up to the runner's macOS version
+          # too, which would exclude most of the Intel Macs still in use. The
+          # omp pragma is simply ignored without it, so the spot-mask outlier
+          # detection runs serially and nothing else changes.
+          # (macos-13 was removed by GitHub: that job never got a runner and
+          # hung for the full 24h workflow limit, which is what blocked the
+          # 0.8.6 PyPI release.)
+          - os: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install OpenMP (macOS)
-        if: runner.os == 'macOS'
+        if: matrix.openmp
         run: brew install libomp
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
+        env:
+          CIBW_ENVIRONMENT_MACOS: ${{ matrix.cibw_env_macos }}
 
       - name: Verify each wheel contains the C extension
         shell: bash
@@ -424,3 +445,23 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  verify_release_complete:
+    # The 0.8.6 release created the GitHub release but published nothing to
+    # PyPI: one wheel job failed and pypi-publish was silently *skipped*, so
+    # the run needed a click-through to notice. This job makes that loud.
+    name: Verify the release is complete
+    needs: [create_release, pypi-publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PyPI publishing did not run
+        run: |
+          publish="${{ needs.pypi-publish.result }}"
+          if [ "$publish" != "success" ]; then
+            echo "::error::PyPI publish did not succeed (result: $publish)."
+            echo "The GitHub release and its executables may still exist,"
+            echo "so check what is already published before re-tagging."
+            exit 1
+          fi
+          echo "GitHub release and PyPI publish both succeeded."

--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,10 @@
 
 - setting an integer intensity factor (e.g. from a script) silently wrapped uint16 image pixel values around; the factor is now coerced to float
 
+## Distribution
+
+- 0.8.6 never reached PyPI: the Apple-silicon wheel failed because Homebrew's OpenMP library requires a newer macOS than the wheel was tagged for, and the Intel wheel job waited 24 hours for a runner that GitHub has retired — with one wheel job failing, the publishing step was skipped without the release run drawing attention to it. The Apple-silicon wheel is now built for macOS 14 and later, the Intel wheel is built on a current runner without OpenMP (so it keeps working on older macOS, with the spot mask running serially), and a final check now fails the release run if publishing did not happen
+
 ## Internal
 
 - restoring settings from a project file no longer needs per-field code: the generic params documents are applied wholesale on top of the legacy restore, so any settings field added in future round-trips automatically


### PR DESCRIPTION
**0.8.6 was never published to PyPI** — the latest version there is still 0.8.5, with zero files for 0.8.6. The GitHub release and executables were created normally, which is why it went unnoticed.

## Two independent macOS wheel failures

**`macos-14` (arm64) — failed in 34 s:**
```
DelocationError: Library dependencies do not satisfy target MacOS version 11.0:
  .dylibs/libomp.dylib has a minimum target of 14.0
```
Homebrew's libomp on that runner targets macOS 14; cibuildwheel tags arm64 wheels `macosx_11_0`; delocate refuses the mismatch. Not transient — it would fail identically for 0.8.7.

**`macos-13` (Intel) — hung for exactly 24 h:** started 14:16:18, cancelled 14:16:19 the next day, the workflow maximum. GitHub retired that image, so the label never gets a runner.

**Why nothing published:** `pypi-publish` needs `build_wheels`, so one failed leg made it **skip** rather than fail. The run reported "failure" only via a job nobody had to look at, and the perfectly good Linux/Windows wheels never went out either.

## Fixes

- **arm64**: `MACOSX_DEPLOYMENT_TARGET=14.0`, keeping OpenMP. Apple silicon machines run 14+ in practice; older ones fall back to the sdist.
- **Intel**: `macos-15-intel`, built deliberately **without** OpenMP. Installing libomp there would raise *that* wheel's minimum to the runner's macOS and exclude most remaining Intel Macs. Without it the pragma is ignored and the spot-mask outlier detection runs serially — the same configuration the NumPy fallback path already supports.
- **`verify_release_complete`**: runs with `if: always()` and fails the run when publishing didn't succeed, so this can't be silent again.

## On OpenMP in the PyInstaller builds

Worth recording, since it came up: **the executables already have OpenMP.** `DIOPTAS_NO_OPENMP` exists in `setup.py` but is never set anywhere; the macOS job runs `brew install libomp` and PyInstaller bundles it. The difference isn't capability, it's enforcement — PyInstaller performs no deployment-target check, so it ships the same libomp that delocate rejects for wheels. (Which means whether those app bundles actually run on macOS 11–13 has never been verified — worth a separate look.)

Measured cost of dropping OpenMP, for context: spot-mask outlier detection on a 4.2 Mpx image is 62.7 ms serial vs 13.4 ms on 8 threads.

**This can only really be tested by tagging a release** — CI on this PR doesn't exercise `release.yml`. The YAML parses and the matrix resolves as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)