### PR TITLE
CI: lint for critical defects (syntax, undefined names, shadowed redefinitions)

### DIFF
--- a/.github/workflows/CI_lint.yml
+++ b/.github/workflows/CI_lint.yml
@@ -1,0 +1,27 @@
+# Critical-defect lint: syntax errors, undefined names and shadowed
+# redefinitions. These are the classes of problem the test suite cannot see —
+# a duplicated function body silently loses one copy, an undefined name only
+# blows up on the code path that reaches it. The rule selection lives in
+# pyproject.toml so a local `ruff check` matches CI.
+
+name: CI_lint
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install ruff
+      run: python -m pip install "ruff==0.14.*"
+
+    - name: Lint for critical defects
+      run: ruff check dioptas run.py

--- a/dioptas/controller/CalibrationController.py
+++ b/dioptas/controller/CalibrationController.py
@@ -15,7 +15,6 @@ from .. import calibrants_path
 
 # imports for type hinting in PyCharm -- DO NOT DELETE
 from ..widgets.CalibrationWidget import CalibrationWidget, WIZARD_STEP_TITLES
-from ..widgets.UtilityWidgets import open_file_dialog
 from ..model.DioptasModel import DioptasModel
 from .binding import Binder
 from ..model.CalibrationGuide import CalibrationGuide, Step

--- a/dioptas/controller/integration/BackgroundController.py
+++ b/dioptas/controller/integration/BackgroundController.py
@@ -214,7 +214,7 @@ class BackgroundController:
             binning = self.model.batch_model.binning[start_x:stop_x]
 
             bkg_roi = self.convert_x_value(
-                np.array(pattern.auto_bkg_roi),
+                np.array(roi),
                 self.model.current_configuration.integration_unit,
                 "2th_deg",
             )

--- a/dioptas/model/DioptasModel.py
+++ b/dioptas/model/DioptasModel.py
@@ -33,7 +33,6 @@ from . import (
     PhaseModel,
     PatternModel,
     OverlayModel,
-    MapModel,
     BatchModel,
 )
 from .MapModel import MapModel

--- a/dioptas/tests/controller_tests/test_IntegrationController.py
+++ b/dioptas/tests/controller_tests/test_IntegrationController.py
@@ -186,31 +186,3 @@ class IntegrationControllerTest(QtTest):
             if splitter.widget(ind) == item:
                 return True
         return False
-
-
-    def test_cake_changes_axes(self):
-        # self.assertEqual(self.widget.integration_image_widget.mode_btn.text(), 'Cake')
-        # self.assertEqual(self.widget.integration_image_widget.img_view.left_axis_image,
-        #                  self.widget.integration_image_widget.img_view.pg_layout.getItem(1, 0))
-        self.widget.integration_image_widget.mode_btn.click()  # change to cake mode
-        self.assertEqual(self.widget.integration_image_widget.mode_btn.text(), 'Image')
-        self.assertEqual(self.widget.integration_image_widget.cake_view.left_axis_cake,
-                         self.widget.integration_image_widget.cake_view.pg_layout.getItem(1, 0))
-
-    def test_disable_solid_angle_correction(self):
-        click_checkbox(self.widget.integration_control_widget.integration_options_widget.correct_solid_angle_cb)
-        self.assertFalse(self.model.calibration_model.correct_solid_angle)
-
-    @unittest.skip("Axes are currently not used for 'Image' mode")
-    def test_cake_zoom_changes_axes_scale(self):
-        self.widget.integration_image_widget.mode_btn.click()
-        self.assertEqual(self.widget.integration_image_widget.mode_btn.text(), 'Image')
-        # print(self.widget.integration_image_widget.img_view.left_axis_cake.range)
-        # print(self.widget.integration_image_widget.img_view.img_view_box.viewRange())
-        rect = QtCore.QRectF(512, 512, 512, 512)
-        self.widget.integration_image_widget.img_view.img_view_box.setRange(rect)
-
-        # print(self.widget.integration_image_widget.img_view.left_axis_cake.range)
-        # print(self.widget.integration_image_widget.img_view.img_view_box.viewRange())
-        # print(self.widget.integration_image_widget.img_view.img_view_box.viewRect())
-        self.assertEqual(self.widget.integration_image_widget.img_view.img_view_box.viewRect(), rect)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,11 @@ exclude_lines = [
     "if __name__ == .__main__.",
 ]
 
+
+[tool.ruff.lint]
+# Critical defects only — the classes of problem the test suite cannot see:
+# syntax errors (E9), shadowed redefinitions (F811, a duplicated function
+# body silently loses one copy), undefined names (F821/F823, a NameError on
+# whatever code path reaches them). Style rules are deliberately not
+# enforced here.
+select = ["E9", "F811", "F821", "F823"]


### PR DESCRIPTION
## What this does

Adds a `CI_lint` workflow running ruff with a deliberately narrow rule set — `E9` (syntax errors), `F811` (shadowed redefinitions), `F821`/`F823` (undefined names). These are the defect classes the test suite structurally cannot catch: a duplicated function body silently loses one copy (the reviewer of #249 found 383 lines of exactly that), and an undefined name only raises on the code path that reaches it. No style rules are enforced; the selection lives in `pyproject.toml` so a local `ruff check dioptas run.py` matches CI.

## Fixes required to make the gate start green

The selection finds six pre-existing issues on `develop`, fixed here:

- **A latent `NameError`** in `BackgroundController.update_bkg_gui_parameters`: `pattern.auto_bkg_roi` where no `pattern` exists — hit whenever a background ROI updates while batch data is loaded. The intended value is the `roi` read three lines above.
- **Three silently-never-running tests**: byte-identical shadows of `test_cake_changes_axes`, `test_disable_solid_angle_correction` and `test_cake_zoom_changes_axes_scale` at the tail of `test_IntegrationController.py`.
- Two double imports (`open_file_dialog` in `CalibrationController`, `MapModel` in `DioptasModel`).

## Testing

`ruff check dioptas run.py` clean; the test files around every fix pass (`test_IntegrationController` 9 passed 1 skipped, `test_DioptasModel`/`test_Background*`/`test_Calibration*` 107 passed 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)