### PR TITLE
Dynamic masks recompute on enable; drop the redundant Clear Ring button

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # 0.9.1 (in development)
 
+## Bugfixes
+
+- Re-enabling a dynamic mask after loading a different image showed the mask computed for the previous image; enabling now always recomputes for the image on screen.
+
+## Changes
+
+- The mask plugin settings dialogs gained a **Restore Defaults** button.
+
+- The redundant **Clear Ring** button under the calibration peak table is gone: changing the ring number already selects every group of that ring, so Delete does the same in two steps — the tooltip now says so.
+
 # 0.9.0 (03.08.2026)
 
 ## Breaking changes

--- a/dioptas/controller/CalibrationController.py
+++ b/dioptas/controller/CalibrationController.py
@@ -115,7 +115,6 @@ class CalibrationController:
         self.widget.refine_btn.clicked.connect(self.refine)
 
         self.widget.clear_peaks_btn.clicked.connect(self.clear_peaks)
-        self.widget.clear_ring_btn.clicked.connect(self.clear_current_ring)
         self.widget.peak_num_sb.valueChanged.connect(self.current_ring_changed)
 
         self._updating_peak_table = False
@@ -1149,14 +1148,6 @@ class CalibrationController:
         self.model.calibration_model.clear_peaks()
         self.widget.img_widget.clear_scatter_plot()
         self.widget.peak_num_sb.setValue(1)
-
-    def clear_current_ring(self):
-        """
-        Deletes all peaks for the currently selected ring.
-        """
-        ring_ind = self.widget.peak_num_sb.value() - 1
-        self.model.calibration_model.remove_peaks_by_ring(ring_ind)
-        self.plot_points()
 
     def load_spline_btn_click(self):
         filename = open_file_dialog(

--- a/dioptas/model/MaskPluginManager.py
+++ b/dioptas/model/MaskPluginManager.py
@@ -69,8 +69,12 @@ class MaskPluginManager:
 
         entry.enabled = enabled
 
-        if enabled and entry.cached_mask is None and self._current_img_data is not None:
-            self._compute_plugin_mask(entry)
+        # A dynamic plugin's mask belongs to one particular image, and the
+        # image may have changed while the plugin was off — enabling always
+        # recomputes, otherwise the mask of the previous image comes back.
+        if enabled and self._current_img_data is not None:
+            if entry.plugin.is_dynamic or entry.cached_mask is None:
+                self._compute_plugin_mask(entry)
 
         self.mask_changed.emit()
 
@@ -92,7 +96,9 @@ class MaskPluginManager:
         changed = False
         for entry in self._plugins.values():
             if not entry.enabled:
-                if shape_changed:
+                # a disabled dynamic plugin's cache describes an image that
+                # is now gone; keeping it would show the old mask on enable
+                if shape_changed or entry.plugin.is_dynamic:
                     entry.cached_mask = None
                 continue
 

--- a/dioptas/tests/controller_tests/test_MaskController.py
+++ b/dioptas/tests/controller_tests/test_MaskController.py
@@ -244,5 +244,7 @@ def test_plugin_settings_dialog_restores_defaults(qapp):
 
     dialog.restore_defaults()
 
-    assert received[-1] == {"threshold": 5.0, "iterations": 3, "mode": "fast"}
+    # exactly one emission: per-field ones would recompute the mask once
+    # per field and leave one undo step each
+    assert received == [{"threshold": 5.0, "iterations": 3, "mode": "fast"}]
     dialog.close()

--- a/dioptas/tests/controller_tests/test_MaskController.py
+++ b/dioptas/tests/controller_tests/test_MaskController.py
@@ -224,3 +224,25 @@ class MaskControllerTest(QtTest):
             sys.setrecursionlimit(old_limit)
 
         assert self.model.mask_model.get_img().sum() > 0
+
+
+def test_plugin_settings_dialog_restores_defaults(qapp):
+    """The Restore Defaults button sets every field back to the schema
+    default and pushes the change through the live-update path."""
+    from dioptas.widgets.MaskPluginWidget import MaskPluginSettingsDialog
+
+    schema = {
+        "threshold": {"type": "float", "default": 5.0, "min": 0, "max": 100},
+        "iterations": {"type": "int", "default": 3, "min": 1, "max": 10},
+        "mode": {"type": "choice", "choices": ["fast", "full"], "default": "fast"},
+    }
+    dialog = MaskPluginSettingsDialog(
+        "Test", schema, {"threshold": 42.0, "iterations": 9, "mode": "full"}
+    )
+    received = []
+    dialog.settings_changed.connect(received.append)
+
+    dialog.restore_defaults()
+
+    assert received[-1] == {"threshold": 5.0, "iterations": 3, "mode": "fast"}
+    dialog.close()

--- a/dioptas/tests/unit_tests/test_MaskPlugin.py
+++ b/dioptas/tests/unit_tests/test_MaskPlugin.py
@@ -518,3 +518,45 @@ def test_imprint_bakes_mask_and_disables_plugin():
     assert model.get_img().sum() == 50  # row 0 baked in
     assert not manager.is_enabled("No Settings")
 
+
+
+def test_enabling_after_an_image_change_recomputes_the_mask():
+    """Enable on image A, disable, load same-shaped image B, enable again:
+    the mask shown used to be image A's."""
+    manager = MaskPluginManager()
+    plugin = DynamicMeanPlugin()
+    manager.register(plugin)
+
+    image_a = np.zeros((4, 4))
+    image_a[0, 0] = 100.0  # far above the mean -> masked
+    manager.update_image(image_a)
+    manager.set_enabled(plugin.name, True)
+    mask_a = manager.plugins[plugin.name].cached_mask.copy()
+    assert mask_a[0, 0]
+
+    manager.set_enabled(plugin.name, False)
+    image_b = np.zeros((4, 4))
+    image_b[3, 3] = 100.0  # same shape, different hot pixel
+    manager.update_image(image_b)
+
+    manager.set_enabled(plugin.name, True)
+    mask_b = manager.plugins[plugin.name].cached_mask
+    assert mask_b[3, 3]
+    assert not mask_b[0, 0]  # not image A's mask
+
+
+def test_static_plugin_cache_survives_same_shape_image_changes():
+    """A non-dynamic plugin's mask does not depend on the image, so its
+    cache stays valid across same-shaped images."""
+    manager = MaskPluginManager()
+    plugin = StaticThresholdPlugin()
+    manager.register(plugin)
+
+    manager.update_image(np.ones((4, 4)))
+    manager.set_enabled(plugin.name, True)
+    cached = manager.plugins[plugin.name].cached_mask
+
+    manager.set_enabled(plugin.name, False)
+    manager.update_image(np.ones((4, 4)) * 2)
+    manager.set_enabled(plugin.name, True)
+    assert manager.plugins[plugin.name].cached_mask is cached

--- a/dioptas/widgets/CalibrationWidget.py
+++ b/dioptas/widgets/CalibrationWidget.py
@@ -279,7 +279,6 @@ class CalibrationWidget(QtWidgets.QWidget):
         self.search_size_sb = peak_selection_widget.search_size_sb
         self.automatic_peak_num_inc_cb = peak_selection_widget.automatic_peak_num_inc_cb
         self.clear_peaks_btn = peak_selection_widget.clear_peaks_btn
-        self.clear_ring_btn = peak_selection_widget.clear_ring_btn
         self.peak_counter_lbl = peak_selection_widget.peak_counter_lbl
         self.peak_table = peak_selection_widget.peak_table
         self.delete_peak_btn = peak_selection_widget.delete_peak_btn
@@ -972,14 +971,15 @@ class PeakSelectionWidget(QtWidgets.QWidget):
 
         self.delete_peak_btn = QtWidgets.QPushButton("Delete")
         self.delete_peak_btn.setToolTip(
-            'Delete the selected peak groups (Del)')
-        self.clear_ring_btn = QtWidgets.QPushButton("Clear Ring")
+            "Delete the selected peak groups (Del).\n"
+            "Changing the ring number selects every group of that ring,\n"
+            "so a whole ring can be deleted in two steps."
+        )
         self.clear_peaks_btn = QtWidgets.QPushButton("Clear All")
 
         self._peak_btn_layout = QtWidgets.QHBoxLayout()
         self._peak_btn_layout.setSpacing(6)
         self._peak_btn_layout.addWidget(self.delete_peak_btn)
-        self._peak_btn_layout.addWidget(self.clear_ring_btn)
         self._peak_btn_layout.addWidget(self.clear_peaks_btn)
         self._layout.addLayout(self._peak_btn_layout, 6, 0, 1, 4)
 

--- a/dioptas/widgets/MaskPluginWidget.py
+++ b/dioptas/widgets/MaskPluginWidget.py
@@ -167,9 +167,15 @@ class MaskPluginSettingsDialog(QtWidgets.QDialog):
         button_box = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
             | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+            | QtWidgets.QDialogButtonBox.StandardButton.RestoreDefaults
         )
         button_box.accepted.connect(self._on_accept)
         button_box.rejected.connect(self.reject)
+        restore_button = button_box.button(
+            QtWidgets.QDialogButtonBox.StandardButton.RestoreDefaults
+        )
+        restore_button.setToolTip("Set every value back to the plugin's defaults")
+        restore_button.clicked.connect(self.restore_defaults)
         layout.addWidget(button_box)
 
     def _create_widget(self, param_type: str, spec: dict, value) -> QtWidgets.QWidget:
@@ -217,6 +223,30 @@ class MaskPluginSettingsDialog(QtWidgets.QDialog):
             if value is not None:
                 widget.setText(str(value))
             return widget
+
+    def restore_defaults(self):
+        """Sets every field back to its schema default.
+
+        Goes through the widgets rather than the plugin, so the change flows
+        through the same live-update path as manual edits — including undo.
+        """
+        for key, widget in self._widgets.items():
+            spec = self._schema[key]
+            default = spec.get("default")
+            if default is None:
+                continue
+            param_type = spec.get("type", "str")
+            if param_type in ("float", "int"):
+                widget.setValue(default)
+            elif param_type == "bool":
+                widget.setChecked(bool(default))
+            elif param_type == "choice":
+                widget.setCurrentText(str(default))
+            else:
+                # setText emits no editingFinished; the collective emit
+                # below covers it
+                widget.setText(str(default))
+        self._on_value_changed()
 
     def _get_values(self) -> dict:
         values = {}

--- a/dioptas/widgets/MaskPluginWidget.py
+++ b/dioptas/widgets/MaskPluginWidget.py
@@ -229,6 +229,9 @@ class MaskPluginSettingsDialog(QtWidgets.QDialog):
 
         Goes through the widgets rather than the plugin, so the change flows
         through the same live-update path as manual edits — including undo.
+        Widget signals are blocked during the loop and one change is emitted
+        at the end: per-field emissions would recompute the mask once per
+        field and leave one undo step each.
         """
         for key, widget in self._widgets.items():
             spec = self._schema[key]
@@ -236,16 +239,18 @@ class MaskPluginSettingsDialog(QtWidgets.QDialog):
             if default is None:
                 continue
             param_type = spec.get("type", "str")
-            if param_type in ("float", "int"):
-                widget.setValue(default)
-            elif param_type == "bool":
-                widget.setChecked(bool(default))
-            elif param_type == "choice":
-                widget.setCurrentText(str(default))
-            else:
-                # setText emits no editingFinished; the collective emit
-                # below covers it
-                widget.setText(str(default))
+            blocker = QtCore.QSignalBlocker(widget)
+            try:
+                if param_type in ("float", "int"):
+                    widget.setValue(default)
+                elif param_type == "bool":
+                    widget.setChecked(bool(default))
+                elif param_type == "choice":
+                    widget.setCurrentText(str(default))
+                else:
+                    widget.setText(str(default))
+            finally:
+                del blocker
         self._on_value_changed()
 
     def _get_values(self) -> dict:


### PR DESCRIPTION
## What this does

Two post-0.9.0 fixes from usage feedback:

### Dynamic masks showed the previous image's mask
Enable a dynamic mask on image A → disable → load same-shaped image B → enable: the mask shown was image A's. Two holes in `MaskPluginManager`: `update_image` only dropped a *disabled* plugin's cache when the shape changed, and `set_enabled(True)` only recomputed when no cache existed. Loading an image now invalidates disabled **dynamic** plugins' caches, and enabling a dynamic plugin always recomputes for the image on screen. A non-dynamic plugin's image-independent cache still survives — regression tests cover both directions.

The plugin settings dialogs also gain a **Restore Defaults** button (standard `RestoreDefaults` role), pushing the defaults through the same live-update path as manual edits.

### Clear Ring under the calibration peak table
Changing the ring number already selects every group of that ring in the peak table, so **Delete** does exactly what **Clear Ring** did — the button predates the table, when it was the only granular removal. It's removed; Delete's tooltip now points out the two-step path. `remove_peaks_by_ring` stays as model API (used by undo tests).

## Testing

`test_MaskPlugin` 31 passed (2 new), `test_MaskController` 10 passed (1 new), calibration controller/model/undo suites 197 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)