### PR TITLE
Poll for new files so autoprocess works on network drives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - Re-enabling a dynamic mask after loading a different image showed the mask computed for the previous image; enabling now always recomputes for the image on screen.
 
+- **autoprocess** now notices new images on beamline network storage. It used to rely on OS file events, which never reach the machine when the detector writes to a network drive; the folder is now checked directly about once a second instead, which works on any filesystem. A file is only loaded once it has stopped growing, so half-written images no longer slip through.
+
 ## Changes
 
 - The mask plugin settings dialogs gained a **Restore Defaults** button.

--- a/dioptas/model/util/NewFileWatcher.py
+++ b/dioptas/model/util/NewFileWatcher.py
@@ -87,7 +87,10 @@ class NewFileInDirectoryWatcher:
             return
         self.active = False
         self._stop_event.set()
-        self._poll_thread.join()
+        # file_added handlers run on the poll thread; one of them turning
+        # the watcher off must not join the very thread it runs on
+        if threading.current_thread() is not self._poll_thread:
+            self._poll_thread.join()
 
     @property
     def path(self) -> str:

--- a/dioptas/model/util/NewFileWatcher.py
+++ b/dioptas/model/util/NewFileWatcher.py
@@ -4,13 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 import threading
-
-import queue
-
-from watchdog.observers import Observer
-from watchdog.events import FileSystemEvent, PatternMatchingEventHandler
 
 from . import Signal
 
@@ -19,7 +13,20 @@ logger = logging.getLogger(__name__)
 
 class NewFileInDirectoryWatcher:
     """
-    This class watches a given filepath for any new files with a given file extension added to it.
+    This class watches a given filepath for any new files with a given file
+    extension added to it.
+
+    It polls the directory instead of subscribing to OS file events on
+    purpose: inotify (Linux) and FSEvents (macOS) only report changes made
+    through the local kernel. At a beamline the detector server writes to
+    network storage and Dioptas reads a client mount, where such events never
+    arrive at all — while a fresh directory listing sees the new file on any
+    filesystem.
+
+    A new file is announced only once its size and modification time have
+    stayed the same over two consecutive polls and it is not empty, so a file
+    still being written — network filesystems flush in bursts — is left alone
+    until the writer is done.
 
     Typical usage::
         def callback_fcn(path):
@@ -32,112 +39,154 @@ class NewFileInDirectoryWatcher:
 
     def __init__(
         self,
-        path: str | None = None,
+        path: str | os.PathLike | None = None,
         file_types: list[str] | None = None,
         activate: bool = False,
+        poll_interval: float = 1.0,
     ) -> None:
         """
         :param path: path to folder which will be watched
         :param file_types: list of file types which will be watched for, e.g. ['.tif', '.jpeg']
         :param activate: whether the Watcher will already emit signals
+        :param poll_interval: seconds between two looks at the directory
         """
-
         if path is None:
             path = os.getcwd()
-        self._path: str = path
+        self._path: str = str(path)
 
-        if file_types is None:
-            self.file_types: set[str] = set([])
-            self.patterns: str | list[str] = "*"
-        else:
-            self.file_types = set(file_types)
-            self.patterns = ["*." + file_type for file_type in file_types]
+        self.file_types: set[str] = set(file_types) if file_types else set()
+        self.poll_interval: float = poll_interval
 
-        self.event_handler: PatternMatchingEventHandler = PatternMatchingEventHandler(
-            patterns=self.patterns
-        )
-        self.event_handler.on_created = self.on_file_created
+        self.file_added: Signal = Signal(str)  # to be used signal from outside
 
         self.active: bool = False
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        # files already announced (or present before watching started) and
+        # files seen once but not yet stable, with their (size, mtime)
+        self._known: set[str] = set()
+        self._pending: dict[str, tuple[int, float]] = {}
+
         if activate:
             self.activate()
 
-        self.file_added: Signal = Signal(str)  # to be used signal from outside
-        self.filepath_queue: queue.Queue[str] = queue.Queue()
-
-    def on_file_created(self, event: FileSystemEvent) -> None:
-        """
-        Called when a new file is created in the watched directory. This function will be called by the watchdog
-        event handle. We check whether the file is fully written by observing whether the file size changes. If the
-        file size is not changing within 10ms, we assume that the file is fully written and emit the file_added signal.
-        """
-        logger.info("New file detected: %s", event.src_path)
-        file_path = os.path.abspath(event.src_path)
-        try:
-            file_size = os.stat(file_path).st_size
-        except FileNotFoundError:
-            return
-        while True:
-            try:
-                new_size = os.stat(file_path).st_size
-            except FileNotFoundError:
-                return
-            if new_size == file_size:
-                break
-            file_size = new_size
-            time.sleep(0.01)
-
-        self.filepath_queue.put(os.path.abspath(file_path))
-
     def activate(self) -> None:
-        if not self.active:
-            self.active = True
-            self.queue_thread: threading.Thread = threading.Thread(
-                target=self.process_events, daemon=True
-            )
-            self.queue_thread.start()
-            self._start_observing()
+        if self.active:
+            return
+        self.active = True
+        self._stop_event.clear()
+        with self._lock:
+            self._take_baseline()
+        self._poll_thread: threading.Thread = threading.Thread(
+            target=self._poll_loop, daemon=True
+        )
+        self._poll_thread.start()
 
     def deactivate(self) -> None:
-        if self.active:
-            self.active = False
-            self._stop_observing()
-            self.queue_thread.join()
-
-    def _start_observing(self) -> None:
-        self.observer: Observer = Observer()
-        self.observer.schedule(self.event_handler, self.path)
-        self.observer.start()
-
-    def _stop_observing(self) -> None:
-        if self.observer.is_alive():
-            self.observer.stop()
-            self.observer.join()
+        if not self.active:
+            return
+        self.active = False
+        self._stop_event.set()
+        self._poll_thread.join()
 
     @property
     def path(self) -> str:
         return self._path
 
     @path.setter
-    def path(self, new_path: str) -> None:
-        if self.active:
-            self._stop_observing()
-        self._path = new_path
-        if self.active:
-            self._start_observing()
+    def path(self, new_path: str | os.PathLike) -> None:
+        with self._lock:
+            self._path = str(new_path)
+            # only files added from now on count, as for the initial path
+            self._take_baseline()
 
-    def process_events(self) -> None:
-        """continuously check for new files and emit the file_added signal"""
-        while self.active:
-            try:
-                file_path = self.filepath_queue.get(False)  # doesn't block
-            except queue.Empty:  # raised when the queue is empty
-                time.sleep(0.05)
-                continue
+    def _poll_loop(self) -> None:
+        # Event.wait doubles as an interruptible sleep, so deactivate() never
+        # has to wait out a full interval
+        while not self._stop_event.wait(self.poll_interval):
+            self.poll_once()
 
+    def poll_once(self) -> None:
+        """One look at the directory; called repeatedly by the poll thread.
+
+        Emits file_added for every file that appeared since watching started
+        and has finished being written (stats unchanged since the last look).
+        """
+        with self._lock:
+            entries = self._scan()
+            if entries is None:
+                return
+
+            # a vanished file may be re-created later; that counts as new again
+            self._known &= set(entries)
+            for name in list(self._pending):
+                if name not in entries:
+                    del self._pending[name]
+
+            ready: list[tuple[float, str]] = []
+            for name, file_stat in entries.items():
+                if name in self._known:
+                    continue
+                if self._pending.get(name) == file_stat and file_stat[0] > 0:
+                    ready.append((file_stat[1], name))
+                    self._known.add(name)
+                    del self._pending[name]
+                else:
+                    self._pending[name] = file_stat
+
+            new_file_paths = [
+                os.path.abspath(os.path.join(self._path, name))
+                for _, name in sorted(ready)
+            ]
+
+        # emitted outside the lock so a handler may touch the watcher
+        for file_path in new_file_paths:
+            logger.info("New file detected: %s", file_path)
             self.file_added.emit(file_path)
 
+    def _scan(self) -> dict[str, tuple[int, float]] | None:
+        """Lists the matching files with their (size, mtime).
+
+        Opens the directory fresh each time — this is also what defeats the
+        NFS attribute cache. Returns None if the directory cannot be read.
+        """
+        try:
+            with os.scandir(self._path) as dir_iterator:
+                entries: dict[str, tuple[int, float]] = {}
+                for entry in dir_iterator:
+                    if not self._matches(entry.name):
+                        continue
+                    try:
+                        if not entry.is_file():
+                            continue
+                        file_stat = entry.stat()
+                    except OSError:
+                        continue
+                    entries[entry.name] = (file_stat.st_size, file_stat.st_mtime)
+                return entries
+        except OSError:
+            logger.debug("Cannot list watched directory: %s", self._path)
+            return None
+
+    def _matches(self, filename: str) -> bool:
+        if not self.file_types:
+            return True
+        lowered = filename.lower()
+        return any(
+            lowered.endswith("." + file_type.lower().lstrip("."))
+            for file_type in self.file_types
+        )
+
+    def _take_baseline(self) -> None:
+        """Remembers the files already there, which are never announced."""
+        entries = self._scan()
+        self._known = set(entries) if entries else set()
+        self._pending = {}
+
     def __del__(self) -> None:
-        """Stop the observer thread when the object is deleted."""
-        self.deactivate()
-        self.file_added.clear()
+        """Stop the poll thread when the object is deleted."""
+        try:
+            self.deactivate()
+            self.file_added.clear()
+        except Exception:
+            pass

--- a/dioptas/tests/unit_tests/test_NewFileInDirectoryWatcher.py
+++ b/dioptas/tests/unit_tests/test_NewFileInDirectoryWatcher.py
@@ -146,6 +146,34 @@ def test_batch_of_files_is_emitted_in_mtime_order(tmp_path):
     ]
 
 
+def test_deactivating_from_inside_a_handler_does_not_deadlock(tmp_path):
+    # handlers run on the poll thread; a handler turning the watcher off
+    # must not make deactivate() join the thread it is running on
+    watcher = NewFileInDirectoryWatcher(
+        str(tmp_path), file_types=["tif"], poll_interval=0.02
+    )
+    received = []
+
+    def handler(path):
+        received.append(path)
+        watcher.deactivate()
+
+    watcher.file_added.connect(handler)
+    watcher.activate()
+    try:
+        (tmp_path / "image.tif").write_bytes(b"image")
+        timeout = time.time() + 5.0
+        while not received and time.time() < timeout:
+            time.sleep(0.01)
+    finally:
+        watcher.deactivate()
+
+    assert received == [str(tmp_path / "image.tif")]
+    watcher._poll_thread.join(timeout=5.0)
+    assert not watcher._poll_thread.is_alive()
+    assert not watcher.active
+
+
 def test_end_to_end_with_the_poll_thread(tmp_path):
     watcher = NewFileInDirectoryWatcher(
         str(tmp_path), file_types=["tif"], poll_interval=0.02

--- a/dioptas/tests/unit_tests/test_NewFileInDirectoryWatcher.py
+++ b/dioptas/tests/unit_tests/test_NewFileInDirectoryWatcher.py
@@ -1,48 +1,167 @@
 # SPDX-License-Identifier: MIT
 
+"""The watcher polls the directory rather than listening for OS file events,
+because those events never reach a network-filesystem client — the situation
+at nearly every beamline. Polling also makes the tests deterministic: each
+test drives poll_once() by hand instead of sleeping and hoping."""
+
 import os
 import shutil
-import unittest
+import time
 
 from ...model.util.NewFileWatcher import NewFileInDirectoryWatcher
 
-unittest_data_path = os.path.join(os.path.dirname(__file__), '../data')
+unittest_data_path = os.path.join(os.path.dirname(__file__), "../data")
 
 
-@unittest.skip('inotify Limit does not allow to run this on CI')
-def test_getting_callback_for_new_file(tmp_path):
-    directory_watcher = NewFileInDirectoryWatcher()
-
-    def callback_fcn(filepath):
-        assert filepath == os.path.abspath(os.path.join(tmp_path, 'image_003.tif'))
-
-    directory_watcher.path = tmp_path
-    directory_watcher.file_added.connect(callback_fcn)
-    directory_watcher.file_types.add('.tif')
-    directory_watcher.activate()
-
-    shutil.copy2(os.path.join(unittest_data_path, 'image_001.tif'),
-                 os.path.join(tmp_path, 'image_003.tif'))
-
-    directory_watcher.deactivate()
+def make_watcher(tmp_path, **kwargs):
+    kwargs.setdefault("file_types", ["tif"])
+    watcher = NewFileInDirectoryWatcher(str(tmp_path), **kwargs)
+    received = []
+    watcher.file_added.connect(received.append)
+    # what activate() does, minus the poll thread — the tests poll by hand
+    watcher._take_baseline()
+    return watcher, received
 
 
-@unittest.skip('inotify Limit does not allow to run this on CI')
-def test_filename_is_emitted_with_full_file_available(tmp_path):
-    directory_watcher = NewFileInDirectoryWatcher()
-    original_path = os.path.join(unittest_data_path, 'image_001.tif')
-    destination_path = os.path.join(tmp_path, 'image_003.tif')
-    original_filesize = os.stat(original_path).st_size
+def test_new_file_is_emitted_once_written_and_stable(tmp_path):
+    watcher, received = make_watcher(tmp_path)
 
-    def callback_fcn(filepath):
-        filesize = os.stat(filepath).st_size
-        assert filesize == original_filesize
+    destination = os.path.join(tmp_path, "image_003.tif")
+    shutil.copy2(os.path.join(unittest_data_path, "image_001.tif"), destination)
 
-    directory_watcher.path = tmp_path
-    directory_watcher.file_added.connect(callback_fcn)
-    directory_watcher.file_types.add('.tif')
-    directory_watcher.activate()
+    # first sighting only records the file; the second poll finds it
+    # unchanged and announces it
+    watcher.poll_once()
+    assert received == []
+    watcher.poll_once()
+    assert received == [os.path.abspath(destination)]
 
-    shutil.copy2(original_path, destination_path)
+    # and never again
+    watcher.poll_once()
+    assert received == [os.path.abspath(destination)]
 
-    directory_watcher.deactivate()
+
+def test_growing_file_is_held_back_until_it_stops_changing(tmp_path):
+    watcher, received = make_watcher(tmp_path)
+
+    destination = tmp_path / "image_003.tif"
+    with open(destination, "wb") as f:
+        f.write(b"x" * 100)
+        f.flush()
+        watcher.poll_once()
+        f.write(b"x" * 100)
+        # mtime resolution can be coarser than this test is fast
+        os.utime(destination, (time.time(), time.time() + 1))
+
+    watcher.poll_once()
+    assert received == [], "file changed between polls, must not be announced"
+    watcher.poll_once()
+    assert received == [str(destination)]
+
+
+def test_empty_file_is_not_announced(tmp_path):
+    watcher, received = make_watcher(tmp_path)
+
+    destination = tmp_path / "image_003.tif"
+    destination.touch()
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [], "a zero-byte placeholder is not a finished file"
+
+    destination.write_bytes(b"content")
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [str(destination)]
+
+
+def test_preexisting_files_are_not_emitted(tmp_path):
+    (tmp_path / "old_image.tif").write_bytes(b"already there")
+    watcher, received = make_watcher(tmp_path)
+
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == []
+
+    (tmp_path / "new_image.tif").write_bytes(b"new")
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [str(tmp_path / "new_image.tif")]
+
+
+def test_only_watched_file_types_are_announced(tmp_path):
+    watcher, received = make_watcher(tmp_path)
+
+    (tmp_path / "notes.txt").write_bytes(b"not an image")
+    (tmp_path / "image.tif").write_bytes(b"image")
+    (tmp_path / "loud_image.TIF").write_bytes(b"image")  # detectors shout
+    watcher.poll_once()
+    watcher.poll_once()
+    assert sorted(received) == [
+        str(tmp_path / "image.tif"),
+        str(tmp_path / "loud_image.TIF"),
+    ]
+
+
+def test_changing_the_path_starts_fresh(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (second / "existing.tif").write_bytes(b"was there before the switch")
+
+    watcher, received = make_watcher(first)
+    watcher.path = str(second)
+
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [], "files present before the switch are not new"
+
+    (second / "fresh.tif").write_bytes(b"new")
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [str(second / "fresh.tif")]
+
+
+def test_unreadable_directory_is_survived(tmp_path):
+    watcher, received = make_watcher(tmp_path / "does_not_exist")
+    watcher.poll_once()
+    assert received == []
+
+
+def test_batch_of_files_is_emitted_in_mtime_order(tmp_path):
+    watcher, received = make_watcher(tmp_path)
+
+    now = time.time()
+    for index, name in enumerate(["c.tif", "a.tif", "b.tif"]):
+        (tmp_path / name).write_bytes(b"image")
+        os.utime(tmp_path / name, (now + index, now + index))
+
+    watcher.poll_once()
+    watcher.poll_once()
+    assert received == [
+        str(tmp_path / "c.tif"),
+        str(tmp_path / "a.tif"),
+        str(tmp_path / "b.tif"),
+    ]
+
+
+def test_end_to_end_with_the_poll_thread(tmp_path):
+    watcher = NewFileInDirectoryWatcher(
+        str(tmp_path), file_types=["tif"], poll_interval=0.02
+    )
+    received = []
+    watcher.file_added.connect(received.append)
+    watcher.activate()
+    try:
+        destination = os.path.join(tmp_path, "image_003.tif")
+        shutil.copy2(os.path.join(unittest_data_path, "image_001.tif"), destination)
+
+        timeout = time.time() + 5.0
+        while not received and time.time() < timeout:
+            time.sleep(0.01)
+    finally:
+        watcher.deactivate()
+
+    assert received == [os.path.abspath(destination)]
+    assert not watcher._poll_thread.is_alive()


### PR DESCRIPTION
## The problem

Autoprocess relied on watchdog's native observer — inotify on Linux, FSEvents on macOS. Those kernel event systems only report changes made *through the local machine's kernel*. At a beamline the detector server writes to NFS/GPFS/Lustre and Dioptas reads a client mount, where such events never exist — so autoprocess silently did nothing. This is the "does not seem to work due to network hard disk issues" everyone sees; no event was ever going to arrive.

## The fix

`NewFileInDirectoryWatcher` now polls: an `os.scandir` about once a second, opening the directory fresh each time (which also defeats the NFS attribute cache). A file is announced only once its size and mtime have held still across **two consecutive polls** and it is non-empty — replacing the old size-stable-for-10 ms heuristic, far too optimistic for network filesystems that flush writes in bursts. Batches emit in mtime order; deactivation interrupts the poll sleep immediately.

The public surface (`path`, `file_types`, `activate`/`deactivate`, `file_added`) is unchanged, so `ImgModel` needed no changes. Extension matching is now case-insensitive (`.TIF` detectors) and tolerates a leading dot.

This is also phase 1 of live map integration: the same poller becomes the file-based frame source, with HDF5-tail (SWMR) and ZMQ adapters to follow behind the same interface.

## Testing

The old watcher tests were permanently skipped ("inotify limit does not allow to run this on CI"); polling has no such limit, so the 9 new tests actually run — deterministic by driving `poll_once()` by hand (growing file held back, empty placeholder held back, pre-existing files ignored, path switch re-baselines, type filter, mtime ordering, unreadable directory survived) plus one threaded end-to-end test. `ImgModel`/`ImageController`/`HelperModule` suites: 60 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)