### PR TITLE
Clear error messages when the wrong file type is loaded

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ## Changes
 
+- **Clear messages for wrong file types.** Picking the wrong kind of file — a *.poni calibration as an image, an image as a pattern, a pattern as a calibration, and so on — used to crash into a raw error dialog (or, for a pattern loaded as a calibration, silently misbehave). Each loader now explains what the chosen file looks like and where to load it instead, e.g. "It looks like a pyFAI calibration file — use 'Load Calibration' to open it." A failed load leaves the previously loaded data untouched.
+
 - The mask plugin settings dialogs gained a **Restore Defaults** button.
 
 - The redundant **Clear Ring** button under the calibration peak table is gone: changing the ring number already selects every group of that ring, so Delete does the same in two steps — the tooltip now says so.

--- a/dioptas/controller/CalibrationController.py
+++ b/dioptas/controller/CalibrationController.py
@@ -10,6 +10,7 @@ from skimage.measure import find_contours
 
 from ..widgets.UtilityWidgets import open_file_dialog, save_file_dialog
 from ..model.util.HelperModule import get_partial_index, get_partial_value
+from ..model.util.file_type import FileLoadingError
 from .integration.phase.PhaseInPatternController import PhaseInPatternController
 from .. import calibrants_path
 
@@ -297,6 +298,14 @@ class CalibrationController:
         self.model.calibration_model.set_pyFAI(pyFAI_parameter)
         self.update_all()
 
+    def _show_file_error_message(self, message):
+        QtWidgets.QMessageBox.critical(
+            self.widget,
+            "Error",
+            message,
+            QtWidgets.QMessageBox.Ok,
+        )
+
     def _show_incomplete_parameters_message(self, parameter_kind):
         QtWidgets.QMessageBox.critical(
             self.widget,
@@ -500,7 +509,10 @@ class CalibrationController:
 
         if filename != "":
             self.model.working_directories["image"] = os.path.dirname(filename)
-            self.model.img_model.load(filename)
+            try:
+                self.model.img_model.load(filename)
+            except FileLoadingError as e:
+                self._show_file_error_message(str(e))
 
     def load_next_img(self):
         self.model.img_model.load_next_file()
@@ -1376,7 +1388,11 @@ class CalibrationController:
         )
         if filename != "":
             self.model.working_directories["calibration"] = os.path.dirname(filename)
-            self.model.calibration_model.load(filename)
+            try:
+                self.model.calibration_model.load(filename)
+            except FileLoadingError as e:
+                self._show_file_error_message(str(e))
+                return
             self.update_all(integrate=self.model.img_model.filename != "")
 
     def update_mask_gui(self):

--- a/dioptas/controller/MaskController.py
+++ b/dioptas/controller/MaskController.py
@@ -13,6 +13,7 @@ from ..widgets.MaskPluginWidget import MaskPluginSettingsDialog
 # imports for type hinting in PyCharm -- DO NOT DELETE
 from ..widgets.MaskWidget import MaskWidget
 from ..model.DioptasModel import DioptasModel
+from ..model.util.file_type import FileLoadingError
 
 from .binding import Binder
 
@@ -511,7 +512,12 @@ class MaskController:
         if filename != '':
             flipud = selected_filter.startswith(self.FLIPUD_MASK_FILTER_PREFIX)
             self.model.working_directories['mask'] = os.path.dirname(filename)
-            if self.model.mask_model.load_mask(filename, flipud):
+            try:
+                loaded = self.model.mask_model.load_mask(filename, flipud)
+            except FileLoadingError as e:
+                QtWidgets.QMessageBox.critical(self.widget, 'Error', str(e))
+                return
+            if loaded:
                 self.plot_mask()
             else:
                 QtWidgets.QMessageBox.critical(self.widget, 'Error',
@@ -531,7 +537,12 @@ class MaskController:
         if filename != '':
             flipud = selected_filter.startswith(self.FLIPUD_MASK_FILTER_PREFIX)
             self.model.working_directories['mask'] = os.path.dirname(filename)
-            if self.model.mask_model.add_mask(filename, flipud):
+            try:
+                added = self.model.mask_model.add_mask(filename, flipud)
+            except FileLoadingError as e:
+                QtWidgets.QMessageBox.critical(self.widget, 'Error', str(e))
+                return
+            if added:
                 self.plot_mask()
             else:
                 QtWidgets.QMessageBox.critical(self.widget, 'Error',

--- a/dioptas/controller/integration/BackgroundController.py
+++ b/dioptas/controller/integration/BackgroundController.py
@@ -9,6 +9,7 @@ from ...widgets.UtilityWidgets import open_file_dialog, save_file_dialog
 from ...widgets.integration import IntegrationWidget
 from ...model.DioptasModel import DioptasModel
 from ...model.ImgModel import BackgroundDimensionWrongException
+from ...model.util.file_type import FileLoadingError
 from ..binding import Binder
 
 
@@ -131,6 +132,9 @@ class BackgroundController:
                     "Background image does not have the same dimensions as original Image. "
                     + "Resetting Background Image.",
                 )
+                self.widget.bkg_image_filename_lbl.setText("None")
+            except FileLoadingError as e:
+                QtWidgets.QMessageBox.critical(self.widget, "Error", str(e))
                 self.widget.bkg_image_filename_lbl.setText("None")
 
     def remove_background_image(self):

--- a/dioptas/controller/integration/ImageController.py
+++ b/dioptas/controller/integration/ImageController.py
@@ -14,6 +14,7 @@ from ...widgets.UtilityWidgets import open_file_dialog, open_files_dialog, save_
 from ...widgets.integration import IntegrationWidget
 from ...model.DioptasModel import DioptasModel
 from ...model.util.HelperModule import get_partial_index, get_partial_value
+from ...model.util.file_type import FileLoadingError
 
 from .EpicsController import EpicsController
 
@@ -281,29 +282,36 @@ class ImageController:
 
         if filenames is not None and len(filenames) != 0:
             self.model.working_directories['image'] = os.path.dirname(str(filenames[0]))
-            if len(filenames) == 1:
+            try:
+                self._load_files(filenames)
+            except FileLoadingError as e:
+                self.model.img_model.blockSignals(False)
+                self.widget.show_error_msg(str(e))
+
+    def _load_files(self, filenames):
+        if len(filenames) == 1:
+            self.model.img_model.load(str(filenames[0]))
+        else:
+            if self.widget.img_batch_mode_add_rb.isChecked():
+                self.model.img_model.blockSignals(True)
                 self.model.img_model.load(str(filenames[0]))
-            else:
-                if self.widget.img_batch_mode_add_rb.isChecked():
-                    self.model.img_model.blockSignals(True)
-                    self.model.img_model.load(str(filenames[0]))
-                    for ind in range(1, len(filenames)):
-                        self.model.img_model.add(filenames[ind])
-                    self.model.img_model.blockSignals(False)
-                    self.model.img_model.img_changed.emit()
-                if self.widget.img_batch_mode_average_rb.isChecked():
-                    self.model.img_model.blockSignals(True)
-                    self.model.img_model.load(str(filenames[0]))
-                    for ind in range(1, len(filenames)):
-                        self.model.img_model.add(filenames[ind])
-                    self.model.img_model._img_data = self.model.img_model._img_data / len(filenames)
-                    self.model.img_model._calculate_img_data()
-                    self.model.img_model.blockSignals(False)
-                    self.model.img_model.img_changed.emit()
-                elif self.widget.img_batch_mode_integrate_rb.isChecked():
-                    self._load_multiple_files(filenames)
-                elif self.widget.img_batch_mode_image_save_rb.isChecked():
-                    self._save_multiple_image_files(filenames)
+                for ind in range(1, len(filenames)):
+                    self.model.img_model.add(filenames[ind])
+                self.model.img_model.blockSignals(False)
+                self.model.img_model.img_changed.emit()
+            if self.widget.img_batch_mode_average_rb.isChecked():
+                self.model.img_model.blockSignals(True)
+                self.model.img_model.load(str(filenames[0]))
+                for ind in range(1, len(filenames)):
+                    self.model.img_model.add(filenames[ind])
+                self.model.img_model._img_data = self.model.img_model._img_data / len(filenames)
+                self.model.img_model._calculate_img_data()
+                self.model.img_model.blockSignals(False)
+                self.model.img_model.img_changed.emit()
+            elif self.widget.img_batch_mode_integrate_rb.isChecked():
+                self._load_multiple_files(filenames)
+            elif self.widget.img_batch_mode_image_save_rb.isChecked():
+                self._save_multiple_image_files(filenames)
 
     def _load_multiple_files(self, filenames):
         if not self.model.calibration_model.is_calibrated:
@@ -318,26 +326,27 @@ class ImageController:
                                                           len(filenames))
         self._set_up_batch_processing()
 
-        for ind in range(len(filenames)):
-            filename = str(filenames[ind])
-            base_filename = os.path.basename(filename)
+        try:
+            for ind in range(len(filenames)):
+                filename = str(filenames[ind])
+                base_filename = os.path.basename(filename)
 
-            progress_dialog.setValue(ind)
-            progress_dialog.setLabelText("Integrating: " + base_filename)
+                progress_dialog.setValue(ind)
+                progress_dialog.setLabelText("Integrating: " + base_filename)
 
-            self.model.img_model.blockSignals(True)
-            self.model.img_model.load(filename)
-            self.model.img_model.blockSignals(False)
+                self.model.img_model.blockSignals(True)
+                self.model.img_model.load(filename)
+                self.model.img_model.blockSignals(False)
 
-            x, y = self.integrate_pattern()
-            self._save_pattern(base_filename, working_directory, x, y)
+                x, y = self.integrate_pattern()
+                self._save_pattern(base_filename, working_directory, x, y)
 
-            QtWidgets.QApplication.processEvents()
-            if progress_dialog.wasCanceled():
-                break
-
-        progress_dialog.close()
-        self._tear_down_batch_processing()
+                QtWidgets.QApplication.processEvents()
+                if progress_dialog.wasCanceled():
+                    break
+        finally:
+            progress_dialog.close()
+            self._tear_down_batch_processing()
 
     def _get_pattern_working_directory(self):
         if self.model.current_configuration.auto_save_integrated_pattern:
@@ -998,7 +1007,11 @@ class ImageController:
             '*.poni')
         if filename != '':
             self.model.working_directories['calibration'] = os.path.dirname(filename)
-            self.model.calibration_model.load(filename)
+            try:
+                self.model.calibration_model.load(filename)
+            except FileLoadingError as e:
+                self.widget.show_error_msg(str(e))
+                return
             self.widget.calibration_lbl.setText(
                 self.model.calibration_model.calibration_name)
             self.widget.wavelength_lbl.setText('{:.4f}'.format(self.model.calibration_model.wavelength * 1e10) + ' A')

--- a/dioptas/controller/integration/PatternController.py
+++ b/dioptas/controller/integration/PatternController.py
@@ -7,6 +7,7 @@ from qtpy import QtWidgets, QtCore
 
 from ...widgets.UtilityWidgets import save_file_dialog, open_file_dialog
 from ...model.util.calc import convert_units
+from ...model.util.file_type import FileLoadingError
 
 # imports for type hinting in PyCharm -- DO NOT DELETE
 from ...model.DioptasModel import DioptasModel
@@ -232,9 +233,13 @@ class PatternController:
 
         if filename != "":
             self.model.working_directories["pattern"] = os.path.dirname(filename)
+            try:
+                self.model.pattern_model.load_pattern(filename)
+            except FileLoadingError as e:
+                self.widget.show_error_msg(str(e))
+                return
             self.widget.pattern_filename_txt.setText(os.path.basename(filename))
             self.widget.pattern_directory_txt.setText(os.path.dirname(filename))
-            self.model.pattern_model.load_pattern(filename)
             self.widget.pattern_next_btn.setEnabled(True)
             self.widget.pattern_previous_btn.setEnabled(True)
 

--- a/dioptas/model/CalibrationModel.py
+++ b/dioptas/model/CalibrationModel.py
@@ -31,6 +31,7 @@ from .util.HelperModule import (
     get_partial_index,
 )
 from .util.calc import supersample_image, trim_trailing_zeros
+from .util.file_type import file_loading_error
 
 logger = logging.getLogger(__name__)
 
@@ -1121,7 +1122,18 @@ class CalibrationModel:
     def load(self, poni_filename: str) -> None:
         """Loads a calibration file and sets all the calibration parameter."""
         logger.info("Loading calibration from %s", poni_filename)
-        poni_dict = PoniFile(poni_filename).as_dict()
+        try:
+            poni_dict = PoniFile(poni_filename).as_dict()
+        except Exception as e:
+            raise file_loading_error(poni_filename, "calibration") from e
+
+        # PoniFile parses any text file without complaint and just leaves the
+        # geometry values at None — treat that as an unreadable file
+        if any(
+            poni_dict.get(key) is None
+            for key in ("dist", "poni1", "poni2", "rot1", "rot2", "rot3")
+        ):
+            raise file_loading_error(poni_filename, "calibration")
 
         if (
             poni_dict.get("poni_version", 1) >= 2

--- a/dioptas/model/ImgModel.py
+++ b/dioptas/model/ImgModel.py
@@ -18,6 +18,7 @@ from .util import Signal
 from .state import ImgParams
 from dioptas.model.loader.spe import SpeFile
 from .util.NewFileWatcher import NewFileInDirectoryWatcher
+from .util.file_type import file_loading_error
 from .util.HelperModule import rotate_matrix_p90, rotate_matrix_m90, FileNameIterator
 from .util.ImgCorrection import (
     ImgCorrectionManager,
@@ -366,7 +367,7 @@ class ImgModel:
             if data:
                 return data
         else:
-            raise IOError("No handler found for given image with filename: " + filename)
+            raise file_loading_error(filename, "image")
 
     def set_loadable_attributes(self, loaded_data: dict[str, Any]) -> None:
         """
@@ -453,10 +454,13 @@ class ImgModel:
             "series_get_image": karabo_file.get_image,
         }
 
-    def load_hdf5(self, filename: str, frame_index: int = 0) -> dict[str, Any]:
+    def load_hdf5(self, filename: str, frame_index: int = 0) -> dict[str, Any] | None:
         """Loads an ESRF hdf5 file."""
-
-        hdf5_image = Hdf5Image(filename)
+        try:
+            hdf5_image = Hdf5Image(filename)
+        except OSError:
+            # not an HDF5 file at all
+            return None
         self.loader = hdf5_image
         self.selected_source = hdf5_image.image_sources[0]
 

--- a/dioptas/model/MaskModel.py
+++ b/dioptas/model/MaskModel.py
@@ -14,6 +14,7 @@ from .util.cosmics import cosmicsimage
 from .util import Signal
 from .state import MaskParams
 from .util.point import Point
+from .util.file_type import file_loading_error
 
 logger = logging.getLogger(__name__)
 
@@ -285,15 +286,18 @@ class MaskModel:
     @staticmethod
     def read_mask_file(filename: str, flipud: bool = False) -> np.ndarray:
         """Load an image mask from file."""
-        if filename.endswith('.npy'):
-            data = np.load(filename)
-        elif filename.endswith('.edf'):
-            data = fabio.open(filename).data
-        else:
-            try:
-                data = np.array(Image.open(filename))
-            except IOError:
-                data = np.loadtxt(filename)
+        try:
+            if filename.endswith('.npy'):
+                data = np.load(filename)
+            elif filename.endswith('.edf'):
+                data = fabio.open(filename).data
+            else:
+                try:
+                    data = np.array(Image.open(filename))
+                except IOError:
+                    data = np.loadtxt(filename)
+        except Exception as e:
+            raise file_loading_error(filename, "mask") from e
 
         if flipud:
             data = np.flipud(data)

--- a/dioptas/model/PatternModel.py
+++ b/dioptas/model/PatternModel.py
@@ -10,6 +10,7 @@ from xypattern.auto_background import SmoothBrucknerBackground
 from .util import Signal
 from .state import PatternParams
 from .util.HelperModule import FileNameIterator, get_base_name
+from .util.file_type import file_loading_error
 
 logger = logging.getLogger(__name__)
 
@@ -185,13 +186,19 @@ class PatternModel:
     def load_pattern(self, filename: str) -> None:
         """Loads a pattern from a tabular pattern file (2 column txt file)."""
         logger.info("Load pattern: {0}".format(filename))
-        self.pattern_filename = filename
-        self.pattern_source = "file"
 
         skiprows = 0
         if filename.endswith(".chi"):
             skiprows = 4
-        self.pattern.load(filename, skiprows)
+        # read the file before touching any state, so a failing load leaves
+        # the model exactly as it was
+        try:
+            self.pattern.load(filename, skiprows)
+        except (ValueError, IndexError, OSError, UnicodeDecodeError) as e:
+            raise file_loading_error(filename, "pattern") from e
+
+        self.pattern_filename = filename
+        self.pattern_source = "file"
         self.file_name_iterator.update_filename(filename)
         self._sync_file_params()
         self.pattern_changed.emit()

--- a/dioptas/model/util/file_type.py
+++ b/dioptas/model/util/file_type.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+"""Best-effort detection of what kind of file the user picked, used to build
+clear error messages when a file cannot be loaded as the expected type
+(e.g. a *.poni calibration selected in the image-loading dialog)."""
+
+import os
+
+# extensions typically produced by detectors / image writers
+_IMAGE_EXTENSIONS = {
+    ".tif", ".tiff", ".cbf", ".edf", ".mar345", ".mar2300", ".mar3450",
+    ".mccd", ".img", ".sfrm", ".spe", ".h5", ".hdf5", ".nxs",
+}
+
+_PATTERN_EXTENSIONS = {".xy", ".chi", ".xye", ".fxye"}
+
+# keys that appear at the start of lines in pyFAI *.poni files (old and new
+# format)
+_PONI_LINE_KEYS = (
+    "poni1:", "poni2:", "distance:", "pixelsize1:", "pixelsize2:",
+    "detector:", "detector_config:", "wavelength:", "rot1:", "rot2:", "rot3:",
+)
+
+
+def detect_file_type(filename):
+    """Guesses the Dioptas-relevant type of a file from its extension and a
+    peek at its content.
+
+    :return: one of "calibration", "pattern", "image", "phase", "project",
+        "mask" or "unknown"
+    """
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".poni":
+        return "calibration"
+    if ext == ".jcpds":
+        return "phase"
+    if ext == ".dio":
+        return "project"
+    if ext == ".mask":
+        return "mask"
+
+    try:
+        with open(filename, "rb") as f:
+            head = f.read(8192)
+    except OSError:
+        return "unknown"
+
+    try:
+        text = head.decode("utf-8")
+    except UnicodeDecodeError:
+        text = None
+
+    if text is None or "\x00" in text:
+        # binary content — in the context of Dioptas almost certainly a
+        # detector image
+        return "image"
+
+    lines = [line.strip() for line in text.splitlines()]
+    lines = [line for line in lines if line and not line.startswith("#")]
+
+    poni_key_count = sum(
+        1 for line in lines if line.lower().startswith(_PONI_LINE_KEYS)
+    )
+    if poni_key_count >= 2:
+        return "calibration"
+
+    numeric_row_count = 0
+    for line in lines[:20]:
+        columns = line.replace(",", " ").split()
+        if len(columns) < 2:
+            continue
+        try:
+            [float(value) for value in columns]
+        except ValueError:
+            continue
+        numeric_row_count += 1
+    if numeric_row_count >= 2:
+        return "pattern"
+
+    if ext in _IMAGE_EXTENSIONS:
+        return "image"
+    if ext in _PATTERN_EXTENSIONS:
+        return "pattern"
+    return "unknown"
+
+
+class FileLoadingError(IOError):
+    """Raised when a file cannot be loaded as the expected type. The message
+    is written for the user and can be shown in a dialog as-is."""
+
+
+_EXPECTED_PHRASES = {
+    "image": "an image",
+    "pattern": "a pattern",
+    "calibration": "a calibration",
+    "mask": "a mask",
+}
+
+_DETECTED_HINTS = {
+    "calibration": 'It looks like a pyFAI calibration file — '
+                   'use "Load Calibration" to open it.',
+    "pattern": "It looks like a diffraction pattern file — "
+               'open it with the "Load" button below the pattern '
+               "in the Integration view.",
+    "image": "It contains binary data, most likely a detector image — "
+             'use "Load Image" to open it.',
+    "phase": "It looks like a JCPDS phase file — "
+             "open it in the Phase tab of the Integration view.",
+    "project": "It looks like a Dioptas project file — "
+               'open it with "Open Project".',
+}
+
+_SUPPORTED_FORMATS = {
+    "image": "Supported image formats include TIFF, CBF, EDF, MarCCD, SPE "
+             "and HDF5-based files.",
+    "pattern": "Pattern files are text files with two numeric columns, "
+               "e.g. *.xy, *.chi or *.dat.",
+    "calibration": "Calibration files are pyFAI *.poni files.",
+    "mask": "Mask files are *.mask, *.npy, *.edf or two-column text files "
+            "matching the image dimensions.",
+}
+
+
+def file_loading_error(filename, expected):
+    """Builds a :class:`FileLoadingError` with a user-readable explanation of
+    why *filename* could not be loaded as *expected* ("image", "pattern",
+    "calibration" or "mask"), including a hint at what the file actually
+    looks like and where to load it instead.
+    """
+    basename = os.path.basename(str(filename))
+    if not os.path.isfile(str(filename)):
+        return FileLoadingError(
+            'Could not load "{}": the file does not exist.'.format(basename)
+        )
+
+    first_line = 'Could not load "{}" as {}.'.format(
+        basename, _EXPECTED_PHRASES[expected]
+    )
+    detected = detect_file_type(str(filename))
+    hint = _DETECTED_HINTS.get(detected)
+    if detected == expected or hint is None or (
+        expected == "mask" and detected == "image"
+    ):
+        # no useful redirection possible — explain what would have worked
+        hint = "The file format was not recognized. " + _SUPPORTED_FORMATS[expected]
+    return FileLoadingError(first_line + "\n" + hint)

--- a/dioptas/tests/unit_tests/test_file_type.py
+++ b/dioptas/tests/unit_tests/test_file_type.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the friendly error messages shown when a file of the wrong type
+is loaded as an image, pattern, calibration or mask."""
+
+import os
+
+import pytest
+
+from ...model.ImgModel import ImgModel
+from ...model.PatternModel import PatternModel
+from ...model.CalibrationModel import CalibrationModel
+from ...model.MaskModel import MaskModel
+from ...model.util.file_type import (
+    FileLoadingError,
+    detect_file_type,
+    file_loading_error,
+)
+
+unittest_path = os.path.dirname(__file__)
+data_path = os.path.join(unittest_path, "../data")
+
+poni_path = os.path.join(data_path, "CeO2_Pilatus1M.poni")
+image_path = os.path.join(data_path, "CeO2_Pilatus1M.tif")
+pattern_path = os.path.join(data_path, "pattern_001.xy")
+
+
+def test_detect_file_type():
+    assert detect_file_type(poni_path) == "calibration"
+    assert detect_file_type(image_path) == "image"
+    assert detect_file_type(pattern_path) == "pattern"
+    # old-style poni content in a txt file is recognized by content
+    assert (
+        detect_file_type(os.path.join(data_path, "wrong_file_format.txt"))
+        == "calibration"
+    )
+
+
+def test_message_for_missing_file():
+    error = file_loading_error("/nonexistent/foo.tif", "image")
+    assert "does not exist" in str(error)
+
+
+@pytest.fixture
+def img_model():
+    return ImgModel()
+
+
+@pytest.fixture
+def pattern_model():
+    return PatternModel()
+
+
+@pytest.fixture
+def mask_model():
+    return MaskModel()
+
+
+def test_img_model_rejects_poni_file(img_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        img_model.load(poni_path)
+    assert "as an image" in str(excinfo.value)
+    assert "Load Calibration" in str(excinfo.value)
+    assert img_model.filename == ""
+
+
+def test_img_model_rejects_pattern_file(img_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        img_model.load(pattern_path)
+    assert "as an image" in str(excinfo.value)
+    assert "pattern" in str(excinfo.value)
+
+
+def test_pattern_model_rejects_image_file(pattern_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        pattern_model.load_pattern(image_path)
+    assert "as a pattern" in str(excinfo.value)
+    assert "Load Image" in str(excinfo.value)
+    # the model state is untouched by the failed load
+    assert pattern_model.pattern_filename == ""
+
+
+def test_pattern_model_rejects_poni_file(pattern_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        pattern_model.load_pattern(poni_path)
+    assert "as a pattern" in str(excinfo.value)
+    assert "Load Calibration" in str(excinfo.value)
+
+
+@pytest.fixture
+def calibration_model(img_model):
+    return CalibrationModel(img_model)
+
+
+def test_calibration_model_rejects_pattern_file(calibration_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        calibration_model.load(pattern_path)
+    assert "as a calibration" in str(excinfo.value)
+    assert not calibration_model.is_calibrated
+
+
+def test_calibration_model_rejects_image_file(calibration_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        calibration_model.load(image_path)
+    assert "as a calibration" in str(excinfo.value)
+    assert not calibration_model.is_calibrated
+
+
+def test_calibration_model_still_loads_valid_poni(calibration_model):
+    calibration_model.load(poni_path)
+    assert calibration_model.is_calibrated
+
+
+def test_mask_model_rejects_poni_file(mask_model):
+    with pytest.raises(FileLoadingError) as excinfo:
+        mask_model.load_mask(poni_path)
+    assert "as a mask" in str(excinfo.value)
+    assert "Load Calibration" in str(excinfo.value)


### PR DESCRIPTION
## What

Picking the wrong kind of file — a `.poni` calibration as an image, an image as a pattern, a pattern as a calibration, and so on — used to crash into the raw traceback dialog. Loading a pattern as a calibration was even worse: pyFAI's `PoniFile` parses any text file without complaint and leaves every geometry value at `None`, silently producing a broken calibration.

Each loader now shows a message that says what the chosen file looks like and where to load it instead, e.g.:

> Could not load "CeO2_Pilatus1M.poni" as an image.
> It looks like a pyFAI calibration file — use "Load Calibration" to open it.

## How

- New `model/util/file_type.py`: best-effort detection of the file kind (extension + content peek: poni-style `key: value` lines, two-column numeric text, binary data) and a `FileLoadingError` (an `IOError` subclass) whose message is written for the user.
- `ImgModel`, `PatternModel`, `CalibrationModel` and `MaskModel` raise it on unreadable files, and a failed load leaves the model state untouched (`PatternModel` previously set `pattern_filename` before reading the file).
- `CalibrationModel.load` validates that dist/poni/rot values are actually present in the parsed poni dict.
- `ImgModel.load_hdf5` no longer lets h5py's raw `OSError: file signature not found` escape the loader chain.
- Controllers (`ImageController`, `PatternController`, `CalibrationController`, `MaskController`, `BackgroundController`) catch `FileLoadingError` and show a normal error box; the multi-file integration loop closes its progress dialog and unblocks signals on failure.

## Tests

10 new tests in `unit_tests/test_file_type.py` covering detection and each model's rejection behavior; full suite passes locally (963 unit/widget/functional + 461 controller tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)